### PR TITLE
[Exercise 1.7] removed redundant ternary operator

### DIFF
--- a/xml/chapter1/section1/subsection7.xml
+++ b/xml/chapter1/section1/subsection7.xml
@@ -620,9 +620,7 @@ function sqrt_iter(guess,x) {
                : sqrt_iter(improve(guess,x),x);
         }
 function good_enough(guess,x) {
-    return (relative_error(guess,improve(guess,x))&lt;error_threshold())
-               ? 1
-               : 0;
+    return (relative_error(guess,improve(guess,x))&lt;error_threshold());
 }
 function relative_error(estimate,reference) {
     return (abs(estimate-reference))/reference;


### PR DESCRIPTION
- redundant ternary operator
- representing numeric values as boolean values not supported in Source