### PR TITLE
Reduce loss of screen real estate by replacing <BR> with &mdash;

### DIFF
--- a/rails/app/assets/stylesheets/application.scss
+++ b/rails/app/assets/stylesheets/application.scss
@@ -174,7 +174,7 @@ form.gsc-search-box,table.gsc-search-box
 
 #gsc-i-id1
 {
-	height:33px !important;
+	height:2em !important;
 	padding:0px !important;
 	background:none !important;
 	text-indent:0px !important;
@@ -189,17 +189,17 @@ button.gsc-search-button
 {
 /*	border-top: 3px solid #666666 !important;
 	border-left: 3px solid #666666 !important; */
-	background-color: #444444 !important;
-        display:block;
-        width: 15px !important;
-        height: 15px !important;
-        border-width:0px !important;
-        margin:0px !important;
-        padding: 7px 7px 5px 7px !important;
-        outline:none;
-        cursor:pointer;
-        box-shadow:none !important;
-        box-sizing: content-box !important;
+	  background-color: #444444 !important;
+    display:block;
+    width: 15px !important;
+    height: 15px !important;
+    border-width:0px !important;
+    margin:0px !important;
+    padding: 7px 7px 5px 7px !important;
+    outline:none;
+    cursor:pointer;
+    box-shadow:none !important;
+    box-sizing: content-box !important;
 }
 
 .gsc-branding
@@ -248,10 +248,10 @@ input.gsc-input {
 #search-box
 {
     position: absolute;
-    right: 0px;
-    top: 55px;
+    right: 1ex;
+    top: 1em;
     width: 250px;
-    height: 26px;
+    height: 2em;
     /* margin:0 auto; */
     background-color: #000000;
     border-radius: 6px;

--- a/rails/app/views/layouts/application.html.erb
+++ b/rails/app/views/layouts/application.html.erb
@@ -69,9 +69,9 @@
       <button id="btn" class="navbar-toggler collapsed" type="button" data-toggle="collapse" data-target="#nav-sidebar" aria-controls="nav-sidebar" aria-expanded="false" aria-label="Toggle navigation" title="navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
-       <a class="navbar-brand navbar-brand-short" href="<%= chapters_path %>/..">S I C P<BR/>J S</a>
+       <a class="navbar-brand navbar-brand-short" href="<%= chapters_path %>/..">S I C P (JS)</a>
        <a class="navbar-brand navbar-brand-long" href="<%= chapters_path %>/..">Structure and Interpretation
-         of Computer Programs<BR/>JavaScript Adaptation</a>
+         of Computer Programs &mdash; JavaScript Adaptation</a>
 
        <!-- edit the search engine by visiting: 
 	    https://cse.google.com/cse/setup/basic?cx=015760785273492757659:nc_tznrzlsg 


### PR DESCRIPTION
The menu used a linebreak to differentiate the title from the
subtitle (JavaScript Adaptation). This wastes a lot of space.
This PR uses an em dash instead for the long title and appends (JS)
for the short title.