### PR TITLE
Fix minor issue in foreword

### DIFF
--- a/xml/others/02foreword02.xml
+++ b/xml/others/02foreword02.xml
@@ -169,7 +169,7 @@ interest in Lisp outside of artificial intelligence.
     </TEXT>
     <TEXT>
 As one would expect from its goals, artificial intelligence research
-gen\-e\-rates many significant programming problems.  In other
+generates many significant programming problems.  In other
 programming cultures this spate of problems spawns new languages.
 Indeed, in any very large programming task a useful organizing
 principle is to control and isolate traffic within the task modules


### PR DESCRIPTION
I was reading through the [foreword](https://sicp.comp.nus.edu.sg/chapters/85) and found this in the last paragraph:
![](https://imgur.com/aSfuKpk.png)

I thought the characters `\-` were out of place and not sure if it served any purpose. Also checked with the MIT [publication](https://web.mit.edu/alexmv/6.037/sicp.pdf) and it didn't seem like the word 'e' in 'generates' were any special. 

Feel free to ignore this PR if the characters were there on purpose!