### PR TITLE
PDF Beautification 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ web:
 
 pdf: 
 	npm start
-	cd latex && latexmk -xelatex -pdf sicpjs
+	cd latex && latexmk -pdflatex=pdflatex -f sicpjs
 
 epub:
 	npm start epub

--- a/nodejs/latexContent.js
+++ b/nodejs/latexContent.js
@@ -15,12 +15,22 @@ const title = `\\begin{titlepage}
 \\end{titlepage}`
 
 export const preamble = `\\documentclass[a4paper, 12pt]{report}
+\\usepackage[T1]{fontenc}
+\\usepackage[utf8]{inputenc}
+\\DeclareUnicodeCharacter{1F00}{-}
+\\usepackage[libertine]{newtxmath}
+\\usepackage{libertine}
+\\usepackage[mono,scale=0.9]{inconsolata}
+\\usepackage[sf,bf,big,raggedright,nobottomtitles]{titlesec}
+\\usepackage[british]{babel}
+
 \\usepackage{adjustbox}
 \\usepackage{amsmath}
 \\usepackage{amssymb}
 \\usepackage{cprotect}
 \\usepackage{csquotes}
 \\usepackage[shortlabels]{enumitem}
+\\setlist{label={--}}
 \\usepackage{etoolbox}
 \\usepackage{float}
 \\usepackage[margin=2.54cm]{geometry}
@@ -63,6 +73,7 @@ export const preamble = `\\documentclass[a4paper, 12pt]{report}
 \\usepackage[answerdelayed]{exercise}
 \\newcounter{ExerciseDisplayNumber}[chapter]
 \\renewcommand{\\theExercise}{\\thechapter.\\arabic{ExerciseDisplayNumber}}
+\\addtolength{\\ExerciseSkipBefore}{1em}
 
 \\usepackage{listings}
 \\expandafter\\patchcmd\\csname \\string\\lstinline\\endcsname{%
@@ -87,7 +98,7 @@ export const preamble = `\\documentclass[a4paper, 12pt]{report}
 
 \\lstset{
    language=JavaScript,
-   basicstyle=\\ttfamily,
+   basicstyle=\\linespread{1.0}\\ttfamily,
    showstringspaces=false,
    showspaces=false,
    escapeinside={/*!}{!*/}

--- a/xml/chapter1/section3/subsection1.xml
+++ b/xml/chapter1/section3/subsection1.xml
@@ -166,7 +166,6 @@ function name(a, b) {
           mathematicians long ago identified the abstraction of
           <INDEX>series, summation of</INDEX><INDEX>summation of a series</INDEX>
           <EM>summation of a series</EM> and invented <QUOTE>sigma
-            <INDEX><LATEXINLINE>$\sum$</LATEXINLINE> (sigma) notation</INDEX>
             <INDEX>sigma@<LATEXINLINE>$\sum$</LATEXINLINE> (sigma) notation</INDEX>
             notation,</QUOTE> for example
           <LATEX>

--- a/xml/chapter1/section3/subsection3.xml
+++ b/xml/chapter1/section3/subsection3.xml
@@ -432,7 +432,7 @@ fixed_point(
           <LATEXINLINE>$y$</LATEXINLINE> such that <LATEXINLINE>$y^2 = x$</LATEXINLINE>.  Putting
           this equation into the equivalent form <LATEXINLINE>$y = x/y$</LATEXINLINE>, we recognize that we
           are looking for a fixed point of the function<FOOTNOTE><LATEXINLINE>$\mapsto$</LATEXINLINE>
-            <INDEX><LATEXINLINE>$\mapsto$</LATEXINLINE> notation for mathematical function</INDEX>
+            <INDEX><LATEXINLINE>$\mapsto$</LATEXINLINE> notation for mathematical function<ORDER>mapsto notation</ORDER></INDEX>
             <INDEX>function (mathematical)<SUBINDEX><LATEXINLINE>$\mapsto$</LATEXINLINE> notation for</SUBINDEX></INDEX>
             (pronounced <QUOTE>maps to</QUOTE>) is
             the mathematician<APOS/>s way of writing


### PR DESCRIPTION
This WIP PR updates the SICP PDF layout to a more modern style following some recent movement in the ACM with their move to libertine and inconsolata. 

It also switches from XeLaTeX to PdfLaTeX which I consider more well-supported and stable. 

There is one remaining issue to work out, something is wrong with the indexing of `(sigma)` in one place. This is somewhat related to the move away from XeLaTeX because XeLaTeX avoids this error by coincidence because it seems to be omitting those index terms. 