### PR TITLE
Fix outdated content of environment model Section 3.2.1

### DIFF
--- a/xml/chapter3/section2/subsection1.xml
+++ b/xml/chapter3/section2/subsection1.xml
@@ -153,14 +153,14 @@ const square = x =&gt; x * x;
         <SPLITINLINE><SCHEME>procedure</SCHEME><JAVASCRIPT>function</JAVASCRIPT></SPLITINLINE>
         body <SPLITINLINE><SCHEME><SCHEMEINLINE>(* x x)</SCHEMEINLINE></SCHEME><JAVASCRIPT><JAVASCRIPTINLINE>return x * x;</JAVASCRIPTINLINE></JAVASCRIPT></SPLITINLINE>.  The environment part of the
         <SPLITINLINE><SCHEME>procedure</SCHEME><JAVASCRIPT>function</JAVASCRIPT></SPLITINLINE>
-        is a pointer to the global environment, since that is the
+        is a pointer to the program environment, since that is the
         environment in which the
 	<SPLITINLINE><SCHEME><SCHEMEINLINE>lambda</SCHEMEINLINE></SCHEME><JAVASCRIPT>function definition</JAVASCRIPT></SPLITINLINE>
 	expression was evaluated to
         produce the
         <SPLITINLINE><SCHEME>procedure</SCHEME><JAVASCRIPT>function</JAVASCRIPT></SPLITINLINE>. A new binding, which associates the
         <SPLITINLINE><SCHEME>procedure</SCHEME><JAVASCRIPT>function</JAVASCRIPT></SPLITINLINE>
-        object with the symbol <SCHEMEINLINE>square</SCHEMEINLINE>, has been added to the global
+        object with the symbol <SCHEMEINLINE>square</SCHEMEINLINE>, has been added to the program
         frame. 
         <SPLITINLINE>
           <SCHEME>


### PR DESCRIPTION
The old version is "Global environment", but I believe with the new syllabus it should be "program environment". I have changed this in my commit. 