### PR TITLE
Fixed a typo in calculating `fibs` via streams.

### DIFF
--- a/xml/chapter3/section5/subsection2.xml
+++ b/xml/chapter3/section5/subsection2.xml
@@ -423,8 +423,8 @@ const integers = pair(1, () => add_streams(ones, integers));
       <JAVASCRIPT>
 const fibs = pair(0,
                   () => pair(1,
-                             () => add_streams(stream_tail(
-                                                      fibs))
+                             () => add_streams(fibs,
+                                               stream_tail(fibs))
                             )
                  );
       </JAVASCRIPT>


### PR DESCRIPTION
`add_streams` needs two args.