### PR TITLE
Fixed `merge` function on page 347

### DIFF
--- a/xml/chapter3/section5/subsection2.xml
+++ b/xml/chapter3/section5/subsection2.xml
@@ -719,7 +719,8 @@ function merge(s1, s2) {
                         () => merge(s1, stream_tail(s2))
                        );
         } else {
-            return merge(stream_tail(s1), stream_tail(s2));
+            return pair(s1head,
+                        () => merge(stream_tail(s1), stream_tail(s2));
         }
     }
 }

--- a/xml/chapter3/section5/subsection2.xml
+++ b/xml/chapter3/section5/subsection2.xml
@@ -423,8 +423,8 @@ const integers = pair(1, () => add_streams(ones, integers));
       <JAVASCRIPT>
 const fibs = pair(0,
                   () => pair(1,
-                             () => add_streams(stream_tail(
-                                                      fibs))
+                             () => add_streams(fibs,
+                                               stream_tail(fibs))
                             )
                  );
       </JAVASCRIPT>

--- a/xml/chapter4/section3/section3.xml
+++ b/xml/chapter4/section3/section3.xml
@@ -52,7 +52,7 @@
 function prime_sum_pair(list1, list2) {    
     const a = an_element_of(list1);
     const b = an_element_of(list2);
-    require(is_prime(a + b);
+    require(is_prime(a + b));
     return list(a, b);
 }
   </JAVASCRIPT>


### PR DESCRIPTION
The problem with this function was that, if you try to do `stream_ref(merge(integers, integers), 3)`,
it will just hang, for an obvious reason.
For the same reason, `merge(int_gen(2,2), int_gen(3,3))` would skip `6`.

The bug is not present in the original lisp source of the original book. It would be cool to have a more correct version in JavaScript.

