### PR TITLE
typos

### DIFF
--- a/xml/chapter4/section1/subsection1.xml
+++ b/xml/chapter4/section1/subsection1.xml
@@ -16,20 +16,6 @@
       <FIGURE src="img_original/ch4-Z-G-1.svg"></FIGURE>
       <LABEL NAME="fig:eval-apply"/>
       <CAPTION>The
-      <SCHEMEINLINE>eval</SCHEMEINLINE><ENDASH/><SCHEMEINLINE>apply</SCHEMEINLINE> 
-      cycle exposes the essence of a computer language.
-      </CAPTION>
-    </FIGURE>
-      </SCHEME>
-      <JAVASCRIPT>
-	<INDEX>metacircular evaluator for JavaScript
-	<SUBINDEX>evaluate@<SCHEMEINLINE>evaluate</SCHEMEINLINE> and 
-	<SCHEMEINLINE>apply</SCHEMEINLINE>|(</SUBINDEX></INDEX>
-
-    <FIGURE>
-      <FIGURE src="img_original/ch4-Z-G-1.svg"></FIGURE>
-      <LABEL NAME="fig:eval-apply"/>
-      <CAPTION>The
       <SCHEMEINLINE>evaluate</SCHEMEINLINE><ENDASH/><SCHEMEINLINE>apply</SCHEMEINLINE> 
       cycle exposes the essence of a computer language.
       </CAPTION>

--- a/xml/chapter4/section3/subsection1.xml
+++ b/xml/chapter4/section3/subsection1.xml
@@ -312,10 +312,10 @@ function an_integer_starting_from(n) {
   has some unusual properties.  It reads an
   expression and prints the value of the first non-failing execution, as
   in the
-  <SPLTINLINE>
+  <SPLITINLINE>
     <SCHEME><SCHEMEINLINE>prime-sum-pair</SCHEMEINLINE></SCHEME>
     <JAVASCRIPT><JAVASCRIPTINLINE>prime_sum_pair</JAVASCRIPTINLINE></JAVASCRIPT>
-  </SPLTINLINE>
+  </SPLITINLINE>
   example shown above.  If we
   want to see the value of the next successful execution, we can
   ask the interpreter to backtrack and attempt to generate a second

--- a/xml/chapter4/section4/section4.xml
+++ b/xml/chapter4/section4/section4.xml
@@ -25,7 +25,7 @@
     <TEXT>
       Most programming languages, including
       <SPLITINLINE><SCHEME>Lisp,</SCHEME>
-      <JAVSCRIPT>JavaScript,</JAVSCRIPT>
+      <JAVASCRIPT>JavaScript,</JAVASCRIPT>
       </SPLITINLINE>
       are organized around
       computing the values of mathematical functions.  Expression-oriented

--- a/xml/chapter4/section4/subsection1.xml
+++ b/xml/chapter4/section4/subsection1.xml
@@ -868,27 +868,27 @@ rule(lives_near(person_1, person_2),
       <SCHEME>
 	<SCHEMEINLINE>?town</SCHEMEINLINE>
       </SCHEME>
-      <JAVASCIPT>
+      <JAVASCRIPT>
 	<JAVASCRIPTINLINE>town</JAVASCRIPTINLINE>
-      </JAVASCIPT>
+      </JAVASCRIPT>
     </SPLITINLINE>
     in the
     <SPLITINLINE>
       <SCHEME>
     <SCHEMEINLINE>lives-near</SCHEMEINLINE>
       </SCHEME>
-      <JAVASCIPT>
+      <JAVASCRIPT>
     <SCHEMEINLINE>lives_near</SCHEMEINLINE>
-      </JAVASCIPT>
+      </JAVASCRIPT>
     </SPLITINLINE>
     rule and
     <SPLITINLINE>
       <SCHEME>
 	<SCHEMEINLINE>?middle-manager</SCHEMEINLINE>
       </SCHEME>
-      <JAVASCIPT>
+      <JAVASCRIPT>
 	<JAVASCRIPTINLINE>middle-manager</JAVASCRIPTINLINE>
-      </JAVASCIPT>
+      </JAVASCRIPT>
     </SPLITINLINE>
     in the
     <SCHEMEINLINE>wheel</SCHEMEINLINE>
@@ -907,27 +907,27 @@ rule(lives_near(person_1, person_2),
       <SCHEME>
 	<SCHEMEINLINE>?person-1</SCHEMEINLINE>
       </SCHEME>
-      <JAVASCIPT>
+      <JAVASCRIPT>
 	<JAVASCRIPTINLINE>person_1</JAVASCRIPTINLINE>
-      </JAVASCIPT>
+      </JAVASCRIPT>
     </SPLITINLINE>
     and
     <SPLITINLINE>
       <SCHEME>
 	<SCHEMEINLINE>?person-2</SCHEMEINLINE>
       </SCHEME>
-      <JAVASCIPT>
+      <JAVASCRIPT>
 	<JAVASCRIPTINLINE>person_2</JAVASCRIPTINLINE>
-      </JAVASCIPT>
+      </JAVASCRIPT>
     </SPLITINLINE>
     in the
     <SPLITINLINE>
       <SCHEME>
 	<SCHEMEINLINE>lives-near</SCHEMEINLINE>
       </SCHEME>
-      <JAVASCIPT>
+      <JAVASCRIPT>
 	<JAVASCRIPTINLINE>"lives-near"</JAVASCRIPTINLINE>
-      </JAVASCIPT>
+      </JAVASCRIPT>
     </SPLITINLINE>
     rule.  Although using the same pattern variable in two
     parts of a query forces the same value to appear in both places, using

--- a/xml/chapter5/section5/section5.xml
+++ b/xml/chapter5/section5/section5.xml
@@ -7,16 +7,16 @@
     <INDEX>compiler|(</INDEX>
     <TEXT>
       The explicit-control evaluator of section<SPACE/><REF NAME="sec:eceval"/> is a
-      register machine whose controller interprets <SPLIT><SCHEME>Scheme</SCHEME><JAVASCRIPT>JavaScript</JAVASCRIPT></SPLIT> programs.  In this
-      section we will see how to run <SPLIT><SCHEME>Scheme</SCHEME><JAVASCRIPT>JavaScript</JAVASCRIPT></SPLIT> programs on a register machine
-      whose controller is not a <SPLIT><SCHEME>Scheme</SCHEME><JAVASCRIPT>JavaScript</JAVASCRIPT></SPLIT> interpreter.
+      register machine whose controller interprets <SPLITINLINE><SCHEME>Scheme</SCHEME><JAVASCRIPT>JavaScript</JAVASCRIPT></SPLITINLINE> programs.  In this
+      section we will see how to run <SPLITINLINE><SCHEME>Scheme</SCHEME><JAVASCRIPT>JavaScript</JAVASCRIPT></SPLITINLINE> programs on a register machine
+      whose controller is not a <SPLITINLINE><SCHEME>Scheme</SCHEME><JAVASCRIPT>JavaScript</JAVASCRIPT></SPLITINLINE> interpreter.
     </TEXT>
 
     <TEXT>
       <INDEX>universal machine<SUBINDEX>explicit-control evaluator as</SUBINDEX></INDEX>
       <INDEX>explicit-control evaluator for Scheme<SUBINDEX>universal@as universal machine</SUBINDEX></INDEX>
       The explicit-control evaluator machine is universal<EMDASH/>it can carry out
-      any computational process that can be described in <SPLIT><SCHEME>Scheme</SCHEME><JAVASCRIPT>JavaScript</JAVASCRIPT></SPLIT>.  The
+      any computational process that can be described in <SPLITINLINE><SCHEME>Scheme</SCHEME><JAVASCRIPT>JavaScript</JAVASCRIPT></SPLITINLINE>.  The
       evaluator<APOS/>s controller orchestrates the use of its data paths to
       perform the desired computation.  Thus, the evaluator<APOS/>s data paths are
       universal: They are sufficient to perform any computation we desire,
@@ -82,7 +82,7 @@
       <INDEX>object program</INDEX>
       <EM>object program</EM>) written in the machine<APOS/>s native language.  The
       compiler that we implement in this section translates programs written
-      in <SPLIT><SCHEME>Scheme</SCHEME><JAVASCRIPT>JavaScript</JAVASCRIPT></SPLIT> into sequences of instructions to be executed using
+      in <SPLITINLINE><SCHEME>Scheme</SCHEME><JAVASCRIPT>JavaScript</JAVASCRIPT></SPLITINLINE> into sequences of instructions to be executed using
       the explicit-control evaluator machine<APOS/>s data 
       paths.<FOOTNOTE>Actually, the machine that runs
   compiled code can be simpler than the interpreter machine, because we


### PR DESCRIPTION
fix typos in xml and change misused <SPLIT> to <SPLITINLINE>