### PR TITLE
bug fixes in xml files

### DIFF
--- a/xml/chapter3/section1/subsection1.xml
+++ b/xml/chapter3/section1/subsection1.xml
@@ -212,7 +212,7 @@ changes <LATEXINLINE>$\textit{name}$</LATEXINLINE> so that its value is the resu
 evaluating <LATEXINLINE>$\textit{new-value}$</LATEXINLINE>.  In the case at hand, 
 we are changing <SCHEMEINLINE>balance</SCHEMEINLINE> so that its new value will be the result of 
 subtracting <SCHEMEINLINE>amount</SCHEMEINLINE> from the previous value 
-of <SCHEMEINLINE>balance</SCHEMEINLINE>.<SPLIT><SCHEME><FOOTNOTE>
+of <SCHEMEINLINE>balance</SCHEMEINLINE>.<SPLITINLINE><SCHEME><FOOTNOTE>
           <!-- \indsf{set!}[value of] -->
           <INDEX>unspecified values<SUBINDEX>set@<SCHEMEINLINE>set!</SCHEMEINLINE></SUBINDEX></INDEX>
           The value of 
@@ -256,7 +256,7 @@ $\textit{expression}_1$ === $\textit{expression}_2$
 	    <JAVASCRIPTINLINE>false</JAVASCRIPTINLINE>, otherwise.
             </FOOTNOTE>
           </JAVASCRIPT>
-        </SPLIT>
+        </SPLITINLINE>
       </TEXT>
 
       <TEXT>

--- a/xml/chapter4/section1/subsection1.xml
+++ b/xml/chapter4/section1/subsection1.xml
@@ -16,6 +16,19 @@
       <FIGURE src="img_original/ch4-Z-G-1.svg"></FIGURE>
       <LABEL NAME="fig:eval-apply"/>
       <CAPTION>The
+      <SCHEMEINLINE>eval</SCHEMEINLINE><ENDASH/><SCHEMEINLINE>apply</SCHEMEINLINE> 
+      cycle exposes the essence of a computer language.
+      </CAPTION>
+    </FIGURE>
+      </SCHEME>
+      <JAVASCRIPT>
+	<INDEX>metacircular evaluator for JavaScript
+	<SUBINDEX>evaluate@<SCHEMEINLINE>evaluate</SCHEMEINLINE> and 
+	<SCHEMEINLINE>apply</SCHEMEINLINE>|(</SUBINDEX></INDEX>
+    <FIGURE>
+      <FIGURE src="img_original/ch4-Z-G-1.svg"></FIGURE>
+      <LABEL NAME="fig:eval-apply"/>
+      <CAPTION>The
       <SCHEMEINLINE>evaluate</SCHEMEINLINE><ENDASH/><SCHEMEINLINE>apply</SCHEMEINLINE> 
       cycle exposes the essence of a computer language.
       </CAPTION>

--- a/xml/chapter4/section1/subsection4.xml
+++ b/xml/chapter4/section1/subsection4.xml
@@ -332,7 +332,7 @@ primitive_constants;
     to the arguments, using the underlying
     <SPLITINLINE><SCHEME>Lisp</SCHEME>
     <JAVASCRIPT>JavaScript</JAVASCRIPT></SPLITINLINE>
-    system:<SPLIT>
+    system:<SPLITINLINE>
     <SCHEME>
       <FOOTNOTE><SCHEMEINLINE>Apply-in-underlying-scheme</SCHEMEINLINE> is the <SCHEMEINLINE>apply</SCHEMEINLINE>
       <SPLITINLINE><SCHEME>procedure</SCHEME><JAVASCRIPT>function</JAVASCRIPT></SPLITINLINE>
@@ -385,7 +385,7 @@ function apply_in_underlying_javascript(prim, argument_list) {
 
       </FOOTNOTE>
     </JAVASCRIPT>
-  </SPLIT>
+  </SPLITINLINE>
 
   <SNIPPET PAGE="382">
     <NAME>apply_primitive_procedure</NAME>

--- a/xml/chapter4/section4/section4.xml
+++ b/xml/chapter4/section4/section4.xml
@@ -96,8 +96,7 @@
   Prolog for representing those
   rules.  
   <INDEX>Kowalski, Robert</INDEX>
-  Kowalski (<CITATION><TEXT>1973</TEXT>Kowalski 1973</CITATION>; 
-  <CITATION><TEXT>1979</TEXT>Kowalski 1979</CITATION>), 
+  <CITATION>Kowalski (1973; 1979)</CITATION>
   in Edinburgh, recognized that execution
   of a Prolog program could be interpreted as proving theorems (using a
   proof technique called linear 

--- a/xml/chapter4/section4/subsection4.xml
+++ b/xml/chapter4/section4/subsection4.xml
@@ -13,7 +13,6 @@
       <SUBSUBSECTION>
   <NAME>The Driver Loop and Instantiation</NAME>
    <LABEL NAME="sec:query-driver"/>
-      </SUBSUBSECTION>
 
   <TEXT>
     <INDEX>driver loop<SUBINDEX>query@in query interpreter</SUBINDEX></INDEX>
@@ -211,11 +210,11 @@ function instantiate(exp, frame, unbound_var_handler) {
     <INDEX>query interpreter<SUBINDEX>instantiation|)</SUBINDEX></INDEX>
     <INDEX>query interpreter<SUBINDEX>driver loop|)</SUBINDEX></INDEX>
   </TEXT>
+      </SUBSUBSECTION>
 
       <SUBSUBSECTION>
   <NAME>The Evaluator</NAME>
   <LABEL NAME="sec:query-eval"/>
-      </SUBSUBSECTION>
 
   <TEXT>
     <INDEX>query interpreter<SUBINDEX>query evaluator|(</SUBINDEX></INDEX>
@@ -590,7 +589,7 @@ function execute(exp) {
     by the
     <SPLITINLINE><SCHEME><SCHEMEINLINE>rule-body</SCHEMEINLINE></SCHEME>
     <JAVASCRIPT><JAVASCRIPTINLINE>rule_body</JAVASCRIPTINLINE></JAVASCRIPT></SPLITINLINE>
-    selector (section<SPACE/><REF NAME="sec:query-syntax"/>)
+    selector (section<SPACE/>7<REF NAME="sec:query-syntax"/>)
     <INDEX>rule (query language)<SUBINDEX>without body</SUBINDEX></INDEX>
     to provide bodies for rules that were
     defined without bodies (that is, rules whose bodies are always
@@ -620,11 +619,11 @@ put("always_true", "qeval", always_true);
     <INDEX>compound query<SUBINDEX>processing|)</SUBINDEX></INDEX>
     <INDEX>query interpreter<SUBINDEX>query evaluator|)</SUBINDEX></INDEX>
   </TEXT>
+      </SUBSUBSECTION>
 
       <SUBSUBSECTION>
   <NAME>Finding Assertions by Pattern Matching</NAME>
   <LABEL NAME="sec:query-match"/>
-      </SUBSUBSECTION>
       
   <TEXT>
     <INDEX>query interpreter<SUBINDEX>pattern matching|(</SUBINDEX></INDEX>
@@ -901,11 +900,11 @@ function extend_if_consistent(variable, dat, frame) {
     <INDEX>pattern matching<SUBINDEX>implementation|)</SUBINDEX></INDEX>
   </TEXT>
   -->
-  
+      </SUBSUBSECTION>
+
       <SUBSUBSECTION>
   <NAME>Rules and Unification</NAME>
   <LABEL NAME="sec:query-unify"/>
-      </SUBSUBSECTION>
       
   <TEXT>
     <INDEX>rule (query language)<SUBINDEX>applying|(</SUBINDEX></INDEX>
@@ -1005,7 +1004,7 @@ function apply_a_rule(rule, query_pattern, query_frame) {
     The selectors
     <SPLITINLINE><SCHEME><SCHEMEINLINE>rule-body</SCHEMEINLINE></SCHEME><JAVASCRIPT><JAVASCRIPTINLINE>rule_body</JAVASCRIPTINLINE></JAVASCRIPT></SPLITINLINE>
     and <SCHEMEINLINE>conclusion</SCHEMEINLINE> that extract parts
-    of a rule are defined in section<SPACE/><REF NAME="sec:query-syntax"/>.
+    of a rule are defined in section<SPACE/>7<REF NAME="sec:query-syntax"/>.
   </TEXT>
 
   <TEXT>
@@ -1347,10 +1346,11 @@ function depends_on(exp, variable, frame) {
     <INDEX>unification<SUBINDEX>implementation|)</SUBINDEX></INDEX>
   </TEXT>
 
+      </SUBSUBSECTION>
+
       <SUBSUBSECTION>
   <NAME>Maintaining the Data Base</NAME>
   <LABEL NAME="sec:query-db"/>
-      </SUBSUBSECTION>
       
   <INDEX>query interpreter<SUBINDEX>data base|(</SUBINDEX></INDEX>
   <TEXT>
@@ -1674,10 +1674,11 @@ function add_assertion(assertion) {
   </EXERCISE>
   <INDEX>query interpreter<SUBINDEX>data base|)</SUBINDEX></INDEX>
 
+      </SUBSUBSECTION>
+
       <SUBSUBSECTION>
   <NAME>Stream Operations</NAME>
   <LABEL NAME="sec:query-streams"/>
-      </SUBSUBSECTION>
       
   <INDEX>query interpreter<SUBINDEX>stream operations|(</SUBINDEX></INDEX>
   <TEXT>
@@ -1797,12 +1798,12 @@ function singleton_stream(x) {
     </SNIPPET>
     <INDEX>query interpreter<SUBINDEX>stream operations|)</SUBINDEX></INDEX>
   </TEXT>
+      </SUBSUBSECTION>
 
       <SUBSUBSECTION>
   <NAME>Query Syntax
     <SPLITINLINE><SCHEME>Procedures</SCHEME><JAVASCRIPT>Functions</JAVASCRIPT></SPLITINLINE></NAME>
       <LABEL NAME="sec:query-syntax"/>
-      </SUBSUBSECTION>
       
   <INDEX>query interpreter<SUBINDEX>syntax of query language|(</SUBINDEX></INDEX>
   <TEXT>
@@ -2134,11 +2135,11 @@ function contract_question_mark(variable) {
     <INDEX>pattern variable<SUBINDEX>representation of|)</SUBINDEX></INDEX>
     <INDEX>query interpreter<SUBINDEX>syntax of query language|)</SUBINDEX></INDEX>
   </TEXT>
+      </SUBSUBSECTION>
 
       <SUBSUBSECTION>
   <NAME>Frames and Bindings</NAME>
   <LABEL NAME="sec:query-bindings"/>
-      </SUBSUBSECTION>
 
   <TEXT>
     <INDEX>query interpreter<SUBINDEX>frame|(</SUBINDEX></INDEX>
@@ -2529,5 +2530,5 @@ sum_of_squares(3, 4);
     answer is probably worth a Ph.D.)
     <LABEL NAME="ex:query-local-names"/>
   </EXERCISE>
-
+    </SUBSUBSECTION>
     </SUBSECTION>

--- a/xml/chapter4/section4/subsection4.xml
+++ b/xml/chapter4/section4/subsection4.xml
@@ -11,10 +11,10 @@
       </TEXT>
 
       <SUBSUBSECTION>
-  <NAME>4.4.4.1<SPACE/><SPACE/>The Driver Loop and Instantiation</NAME>
+  <NAME>The Driver Loop and Instantiation</NAME>
+   <LABEL NAME="sec:query-driver"/>
       </SUBSUBSECTION>
 
-  <LABEL NAME="sec:query-driver"/>
   <TEXT>
     <INDEX>driver loop<SUBINDEX>query@in query interpreter</SUBINDEX></INDEX>
     <INDEX>query interpreter<SUBINDEX>driver loop|(</SUBINDEX></INDEX>
@@ -107,7 +107,7 @@ function query_driver_loop() {
       <JAVASCRIPTINLINE>add_assertion_body</JAVASCRIPTINLINE>,
     </JAVASCRIPT>
   </SPLITINLINE>
-  is given in section<SPACE/>4.4.4.7<!--<REF NAME="sec:query-syntax"/>-->.
+  is given in section<SPACE/><REF NAME="sec:query-syntax"/>.
   <SPLITINLINE>
     <SCHEME>
       <SCHEMEINLINE>Add\?rule\?or-assertion!</SCHEMEINLINE>
@@ -116,7 +116,7 @@ function query_driver_loop() {
       The function <JAVASCRIPTINLINE>add_rule_or_assertion</JAVASCRIPTINLINE>
     </JAVASCRIPT>
   </SPLITINLINE>
-  is defined in section<SPACE/>4.4.4.5<!--<REF NAME="sec:query-db"/>-->.
+  is defined in section<SPACE/><REF NAME="sec:query-db"/>.
   </TEXT>
 
   <TEXT>
@@ -147,7 +147,7 @@ function query_driver_loop() {
       <JAVASCRIPTINLINE>contract_question_mark</JAVASCRIPTINLINE>
     </JAVASCRIPT>
   </SPLITINLINE>
-   (section<SPACE/>4.4.4.7<!--<REF NAME="sec:query-syntax"/>-->).
+   (section<SPACE/><REF NAME="sec:query-syntax"/>).
   </TEXT>
 
   <TEXT>
@@ -207,16 +207,16 @@ function instantiate(exp, frame, unbound_var_handler) {
     The
     <SPLITINLINE><SCHEME>procedures</SCHEME><JAVASCRIPT>functions</JAVASCRIPT></SPLITINLINE>
     that manipulate bindings are defined in
-    section<SPACE/>4.4.4.8<!--<REF NAME="sec:query-bindings"/>-->.
+    section<SPACE/><REF NAME="sec:query-bindings"/>.
     <INDEX>query interpreter<SUBINDEX>instantiation|)</SUBINDEX></INDEX>
     <INDEX>query interpreter<SUBINDEX>driver loop|)</SUBINDEX></INDEX>
   </TEXT>
 
       <SUBSUBSECTION>
-  <NAME>4.4.4.2<SPACE/><SPACE/>The Evaluator</NAME>
-      </SUBSUBSECTION>
-      
+  <NAME>The Evaluator</NAME>
   <LABEL NAME="sec:query-eval"/>
+      </SUBSUBSECTION>
+
   <TEXT>
     <INDEX>query interpreter<SUBINDEX>query evaluator|(</SUBINDEX></INDEX>
     The <SCHEMEINLINE>qeval</SCHEMEINLINE>
@@ -267,7 +267,7 @@ function qeval(query, frame_stream) {
     </SNIPPET>
 
     <SPLITINLINE><SCHEME><SCHEMEINLINE>Type</SCHEMEINLINE></SCHEME>
-    <JAVASCRIPT>The functions <JAVASCRIPTINLINE>type</JAVASCRIPTINLINE></JAVASCRIPT></SPLITINLINE> and <SCHEMEINLINE>contents</SCHEMEINLINE>, defined in section<SPACE/>4.4.4.7<!--<REF NAME="sec:query-syntax"/>-->,
+    <JAVASCRIPT>The functions <JAVASCRIPTINLINE>type</JAVASCRIPTINLINE></JAVASCRIPT></SPLITINLINE> and <SCHEMEINLINE>contents</SCHEMEINLINE>, defined in section<SPACE/><REF NAME="sec:query-syntax"/>,
     implement the abstract syntax of the
     <SPLITINLINE><SCHEME>special forms</SCHEME><JAVASCRIPT>expressions</JAVASCRIPT></SPLITINLINE>.
   </TEXT>
@@ -326,7 +326,7 @@ function simple_query(query_pattern, frame_stream) {
       <JAVASCRIPTINLINE>find_assertions</JAVASCRIPTINLINE>
     </JAVASCRIPT>
   </SPLITINLINE>
-    (section<SPACE/>4.4.4.3<!--<REF NAME="sec:query-match"/>-->) to match the pattern against all
+    (section<SPACE/><REF NAME="sec:query-match"/>) to match the pattern against all
     assertions in the data base, producing a stream of extended frames,
     and we use
   <SPLITINLINE>
@@ -337,7 +337,7 @@ function simple_query(query_pattern, frame_stream) {
       <JAVASCRIPTINLINE>apply_rules</JAVASCRIPTINLINE>
     </JAVASCRIPT>
   </SPLITINLINE>
-    (section<SPACE/>4.4.4.4<!--<REF NAME="sec:query-unify"/>-->) to apply
+    (section<SPACE/><REF NAME="sec:query-unify"/>) to apply
     all possible rules, producing another stream of extended frames.
     These two streams are combined (using
   <SPLITINLINE>
@@ -348,7 +348,7 @@ function simple_query(query_pattern, frame_stream) {
       <JAVASCRIPTINLINE>stream_append_delayed</JAVASCRIPTINLINE>,
     </JAVASCRIPT>
   </SPLITINLINE>
-    section<SPACE/>4.4.4.6<!--<REF NAME="sec:query-streams"/>-->) to make a stream of all the ways that
+    section<SPACE/><REF NAME="sec:query-streams"/>) to make a stream of all the ways that
     the given pattern can be satisfied consistent with the original frame
     (see exercise<SPACE/><REF NAME="ex:q-why-not-append"/>).  The streams for the
     individual input frames are combined using
@@ -360,7 +360,7 @@ function simple_query(query_pattern, frame_stream) {
       <JAVASCRIPTINLINE>stream_flatmap</JAVASCRIPTINLINE>
     </JAVASCRIPT>
   </SPLITINLINE>
-    (section<SPACE/>4.4.4.6<!--<REF NAME="sec:query-streams"/>-->) to form one large stream of all the
+    (section<SPACE/><REF NAME="sec:query-streams"/>) to form one large stream of all the
     ways that any of the frames in the original input stream can be
     extended to produce a match with the given pattern.
     <INDEX>simple query<SUBINDEX>processing|)</SUBINDEX></INDEX>
@@ -433,7 +433,7 @@ put("and", "qeval", conjoin);
     </JAVASCRIPT>
   </SPLITINLINE>
     <SPLITINLINE><SCHEME>procedure</SCHEME><JAVASCRIPT>function</JAVASCRIPT></SPLITINLINE>
-    from section<SPACE/>4.4.4.6<!--<REF NAME="sec:query-streams"/>-->.
+    from section<SPACE/><REF NAME="sec:query-streams"/>.
     (See exercises<SPACE/><REF NAME="ex:q-why-not-append"/> and<SPACE/><REF NAME="ex:q-why-interleave"/>.)
 
     <SNIPPET EVAL="no">
@@ -465,7 +465,7 @@ put("or", "qeval", disjoin);
 
   <TEXT>
     The predicates and selectors for the syntax of conjuncts and disjuncts
-    are given in section<SPACE/>4.4.4.7<!--<REF NAME="sec:query-syntax"/>-->.
+    are given in section<SPACE/><REF NAME="sec:query-syntax"/>.
   </TEXT>
 
   <SUBHEADING>
@@ -590,7 +590,7 @@ function execute(exp) {
     by the
     <SPLITINLINE><SCHEME><SCHEMEINLINE>rule-body</SCHEMEINLINE></SCHEME>
     <JAVASCRIPT><JAVASCRIPTINLINE>rule_body</JAVASCRIPTINLINE></JAVASCRIPT></SPLITINLINE>
-    selector (section<SPACE/>4.4.4.7<!--<REF NAME="sec:query-syntax"/>-->)
+    selector (section<SPACE/><REF NAME="sec:query-syntax"/>)
     <INDEX>rule (query language)<SUBINDEX>without body</SUBINDEX></INDEX>
     to provide bodies for rules that were
     defined without bodies (that is, rules whose bodies are always
@@ -616,16 +616,16 @@ put("always_true", "qeval", always_true);
     The selectors that define the syntax of <SCHEMEINLINE>not</SCHEMEINLINE> and
     <SPLITINLINE><SCHEME><SCHEMEINLINE>lisp-value</SCHEMEINLINE></SCHEME>
     <JAVASCRIPT><JAVASCRIPTINLINE>javascript_value</JAVASCRIPTINLINE></JAVASCRIPT></SPLITINLINE>
-    are given in section<SPACE/>4.4.4.7<!--<REF NAME="sec:query-syntax"/>-->.
+    are given in section<SPACE/><REF NAME="sec:query-syntax"/>.
     <INDEX>compound query<SUBINDEX>processing|)</SUBINDEX></INDEX>
     <INDEX>query interpreter<SUBINDEX>query evaluator|)</SUBINDEX></INDEX>
   </TEXT>
 
       <SUBSUBSECTION>
-  <NAME>4.4.4.3<SPACE/><SPACE/>Finding Assertions by Pattern Matching</NAME>
+  <NAME>Finding Assertions by Pattern Matching</NAME>
+  <LABEL NAME="sec:query-match"/>
       </SUBSUBSECTION>
       
-  <LABEL NAME="sec:query-match"/>
   <TEXT>
     <INDEX>query interpreter<SUBINDEX>pattern matching|(</SUBINDEX></INDEX>
     <INDEX>pattern matching<SUBINDEX>implementation|(</SUBINDEX></INDEX>
@@ -642,7 +642,7 @@ put("always_true", "qeval", always_true);
       <JAVASCRIPT><JAVASCRIPTINLINE>simple_query</JAVASCRIPTINLINE>
       </JAVASCRIPT>
     </SPLITINLINE>
-    (section<SPACE/>4.4.4.2<!--<REF NAME="sec:query-eval"/>-->), takes as input a pattern and a frame.
+    (section<SPACE/><REF NAME="sec:query-eval"/>), takes as input a pattern and a frame.
     It returns a stream of frames, each extending the given one by a
     data-base match of the given pattern.  It uses
     <SPLITINLINE>
@@ -651,7 +651,7 @@ put("always_true", "qeval", always_true);
       <JAVASCRIPT><JAVASCRIPTINLINE>fetch_assertions</JAVASCRIPTINLINE>
       </JAVASCRIPT>
     </SPLITINLINE>
-    (section<SPACE/>4.4.4.5<!--<REF NAME="sec:query-db"/>-->) to get a stream of all the assertions in
+    (section<SPACE/><REF NAME="sec:query-db"/>) to get a stream of all the assertions in
     the data base that should be checked for a match against the pattern
     and the frame.  The reason for
     <SPLITINLINE>
@@ -824,7 +824,7 @@ function extend_if_consistent(variable, dat, frame) {
     simply tests whether the stored and new values are the same.  If so,
     it returns the unmodified frame; if not, it returns a failure
     indication.  The stored value may, however, contain pattern variables
-    if it was stored during unification (see section<SPACE/>4.4.4.4<!--<REF NAME="sec:query-unify"/>-->).
+    if it was stored during unification (see section<SPACE/><REF NAME="sec:query-unify"/>).
     The recursive match of the stored pattern against the new data will add or
     check bindings for the variables in this pattern.  For example,
     suppose we have a frame in which
@@ -857,7 +857,7 @@ function extend_if_consistent(variable, dat, frame) {
     used by
     <SPLITINLINE><SCHEME><SCHEMEINLINE>extend-if-consistent</SCHEMEINLINE></SCHEME><JAVASCRIPT><JAVASCRIPTINLINE>extend_if_consistent</JAVASCRIPTINLINE></JAVASCRIPT></SPLITINLINE>
     to manipulate
-    bindings are defined in section<SPACE/>4.4.4.8<!--<REF NAME="sec:query-bindings"/>-->.
+    bindings are defined in section<SPACE/><REF NAME="sec:query-bindings"/>.
   </TEXT>
 
   <!-- TO BE COMPLETED: IN JAVASCRIPT ADAPTATION, TREATMENT OF PAIR GOES HERE
@@ -903,16 +903,16 @@ function extend_if_consistent(variable, dat, frame) {
   -->
   
       <SUBSUBSECTION>
-  <NAME>4.4.4.4<SPACE/><SPACE/>Rules and Unification</NAME>
+  <NAME>Rules and Unification</NAME>
+  <LABEL NAME="sec:query-unify"/>
       </SUBSUBSECTION>
       
-  <LABEL NAME="sec:query-unify"/>
   <TEXT>
     <INDEX>rule (query language)<SUBINDEX>applying|(</SUBINDEX></INDEX>
     <SPLITINLINE><SCHEME><SCHEMEINLINE>Apply-rules</SCHEMEINLINE></SCHEME><JAVASCRIPT>The function <JAVASCRIPTINLINE>apply_rules</JAVASCRIPTINLINE></JAVASCRIPT></SPLITINLINE>
     is the rule analog of
     <SPLITINLINE><SCHEME><SCHEMEINLINE>find-assertions</SCHEMEINLINE></SCHEME><JAVASCRIPT><JAVASCRIPTINLINE>find_assertions</JAVASCRIPTINLINE></JAVASCRIPT></SPLITINLINE>
-    (section<SPACE/>4.4.4.3<!--<REF NAME="sec:query-match"/>-->).  It
+    (section<SPACE/><REF NAME="sec:query-match"/>).  It
     takes as input a pattern and a frame, and it forms a stream of
     extension frames by applying rules from the data base.
     <SPLITINLINE><SCHEME><SCHEMEINLINE>Stream-flatmap</SCHEMEINLINE></SCHEME><JAVASCRIPT>The function <JAVASCRIPTINLINE>stream_flatmap</JAVASCRIPTINLINE></JAVASCRIPT></SPLITINLINE>
@@ -921,7 +921,7 @@ function extend_if_consistent(variable, dat, frame) {
     down the stream of possibly
     applicable rules (selected by
     <SPLITINLINE><SCHEME><SCHEMEINLINE>fetch-rules</SCHEMEINLINE></SCHEME><JAVASCRIPT><JAVASCRIPTINLINE>fetch_rules</JAVASCRIPTINLINE></JAVASCRIPT></SPLITINLINE>,
-    section<SPACE/>4.4.4.5<!--<REF NAME="sec:query-db"/>-->)
+    section<SPACE/><REF NAME="sec:query-db"/>)
     and combines the resulting streams of frames.
 
     <SNIPPET EVAL="no">
@@ -1005,7 +1005,7 @@ function apply_a_rule(rule, query_pattern, query_frame) {
     The selectors
     <SPLITINLINE><SCHEME><SCHEMEINLINE>rule-body</SCHEMEINLINE></SCHEME><JAVASCRIPT><JAVASCRIPTINLINE>rule_body</JAVASCRIPTINLINE></JAVASCRIPT></SPLITINLINE>
     and <SCHEMEINLINE>conclusion</SCHEMEINLINE> that extract parts
-    of a rule are defined in section<SPACE/>4.4.4.7<!--<REF NAME="sec:query-syntax"/>-->.
+    of a rule are defined in section<SPACE/><REF NAME="sec:query-syntax"/>.
   </TEXT>
 
   <TEXT>
@@ -1025,7 +1025,7 @@ function apply_a_rule(rule, query_pattern, query_frame) {
     <SPLITINLINE><SCHEME><SCHEMEINLINE>new-rule-application\?id</SCHEMEINLINE></SCHEME><JAVASCRIPT><JAVASCRIPTINLINE>new_rule_application_id</JAVASCRIPTINLINE></JAVASCRIPT></SPLITINLINE>
     are included with the syntax
     <SPLITINLINE><SCHEME>procedures</SCHEME><JAVASCRIPT>functions</JAVASCRIPT></SPLITINLINE>
-    in section<SPACE/>4.4.4.7<!--<REF NAME="sec:query-syntax"/>-->.)
+    in section<SPACE/><REF NAME="sec:query-syntax"/>.)
 
     <SNIPPET EVAL="no">
       <SCHEME>
@@ -1348,10 +1348,10 @@ function depends_on(exp, variable, frame) {
   </TEXT>
 
       <SUBSUBSECTION>
-  <NAME>4.4.4.5<SPACE/><SPACE/>Maintaining the Data Base</NAME>
+  <NAME>Maintaining the Data Base</NAME>
+  <LABEL NAME="sec:query-db"/>
       </SUBSUBSECTION>
       
-  <LABEL NAME="sec:query-db"/>
   <INDEX>query interpreter<SUBINDEX>data base|(</SUBINDEX></INDEX>
   <TEXT>
     <INDEX>data base<SUBINDEX>indexing</SUBINDEX></INDEX><INDEX>indexing a data base</INDEX>
@@ -1675,10 +1675,10 @@ function add_assertion(assertion) {
   <INDEX>query interpreter<SUBINDEX>data base|)</SUBINDEX></INDEX>
 
       <SUBSUBSECTION>
-  <NAME>4.4.4.6<SPACE/><SPACE/>Stream Operations</NAME>
+  <NAME>Stream Operations</NAME>
+  <LABEL NAME="sec:query-streams"/>
       </SUBSUBSECTION>
       
-  <LABEL NAME="sec:query-streams"/>
   <INDEX>query interpreter<SUBINDEX>stream operations|(</SUBINDEX></INDEX>
   <TEXT>
     The query system uses a few stream operations that were not presented
@@ -1799,16 +1799,16 @@ function singleton_stream(x) {
   </TEXT>
 
       <SUBSUBSECTION>
-  <NAME>4.4.4.7<SPACE/><SPACE/>Query Syntax
+  <NAME>Query Syntax
     <SPLITINLINE><SCHEME>Procedures</SCHEME><JAVASCRIPT>Functions</JAVASCRIPT></SPLITINLINE></NAME>
+      <LABEL NAME="sec:query-syntax"/>
       </SUBSUBSECTION>
       
-  <LABEL NAME="sec:query-syntax"/>
   <INDEX>query interpreter<SUBINDEX>syntax of query language|(</SUBINDEX></INDEX>
   <TEXT>
     <SPLITINLINE><SCHEME><SCHEMEINLINE>Type</SCHEMEINLINE></SCHEME><JAVASCRIPT>The functions <JAVASCRIPTINLINE>type</JAVASCRIPTINLINE></JAVASCRIPT></SPLITINLINE>
     and <SCHEMEINLINE>contents</SCHEMEINLINE>, used by <SCHEMEINLINE>qeval</SCHEMEINLINE>
-    (section<SPACE/>4.4.4.2<!--<REF NAME="sec:query-eval"/>-->), specify that a
+    (section<SPACE/><REF NAME="sec:query-eval"/>), specify that a
     <SPLITINLINE><SCHEME>special form</SCHEME><JAVASCRIPT>query expression</JAVASCRIPT></SPLITINLINE>
     is identified by <SPLITINLINE><SCHEME>the symbol in its <SCHEMEINLINE>car</SCHEMEINLINE></SCHEME><JAVASCRIPT>name of its operator</JAVASCRIPT></SPLITINLINE>.
     <SPLITINLINE><SCHEME>They are the same as the
@@ -1848,7 +1848,7 @@ function contents(exp) {
     The following
     <SPLITINLINE><SCHEME>procedures</SCHEME><JAVASCRIPT>functions</JAVASCRIPT></SPLITINLINE>, used by
     <SPLITINLINE><SCHEME><SCHEMEINLINE>query-driver-loop</SCHEMEINLINE></SCHEME><JAVASCRIPT><JAVASCRIPTINLINE>query_driver_loop</JAVASCRIPTINLINE></JAVASCRIPT></SPLITINLINE>
-    (in section<SPACE/>4.4.4.1<!--<REF NAME="sec:query-driver"/>-->), specify
+    (in section<SPACE/><REF NAME="sec:query-driver"/>), specify
     that rules and assertions are added to the data base by expressions of
     the form <SPLITINLINE><SCHEME><SCHEMEINLINE>(assert! ^rule-or-assertion^)</SCHEMEINLINE></SCHEME><JAVASCRIPT><JAVASCRIPTINLINE>assert(</JAVASCRIPTINLINE><LATEXINLINE>$\textit{rule-or-assertion}$</LATEXINLINE><JAVASCRIPTINLINE>)</JAVASCRIPTINLINE></JAVASCRIPT></SPLITINLINE>:
 
@@ -1875,7 +1875,7 @@ function add_assertion_body(exp) {
     Here are the syntax definitions for the <SCHEMEINLINE>and</SCHEMEINLINE>, <SCHEMEINLINE>or</SCHEMEINLINE>, <SCHEMEINLINE>not</SCHEMEINLINE>, and
     <SPLITINLINE><SCHEME><SCHEMEINLINE>lisp-value</SCHEMEINLINE> special forms</SCHEME>
     <JAVASCRIPT><JAVASCRIPTINLINE>javascript_value</JAVASCRIPTINLINE> query expressions</JAVASCRIPT></SPLITINLINE>
-    (section<SPACE/>4.4.4.2<!--<REF NAME="sec:query-eval"/>-->):
+    (section<SPACE/><REF NAME="sec:query-eval"/>):
 
     <SNIPPET EVAL="no">
       <SCHEME>
@@ -1963,7 +1963,7 @@ function rule_body(rule) {
     <INDEX>query interpreter<SUBINDEX>pattern-variable representation|(</SUBINDEX></INDEX>
     <INDEX>pattern variable<SUBINDEX>representation of|(</SUBINDEX></INDEX>
     <SPLITINLINE><SCHEME><SCHEMEINLINE>Query-driver-loop</SCHEMEINLINE></SCHEME><JAVASCRIPT>The function <JAVASCRIPTINLINE>query_driver_loop</JAVASCRIPTINLINE></JAVASCRIPT></SPLITINLINE>
-    (section<SPACE/>4.4.4.1<!--<REF NAME="sec:query-driver"/>-->)
+    (section<SPACE/><REF NAME="sec:query-driver"/>)
     calls
      <SPLITINLINE><SCHEME><SCHEMEINLINE>query-syntax-process</SCHEMEINLINE></SCHEME><JAVASCRIPT><JAVASCRIPTINLINE>query_syntax_process</JAVASCRIPTINLINE></JAVASCRIPT></SPLITINLINE>
     to
@@ -2052,7 +2052,7 @@ function expand_question_mark(name) {
     pattern are lists starting with
     <SPLITINLINE><SCHEME><SCHEMEINLINE>?</SCHEMEINLINE></SCHEME><JAVASCRIPT><JAVASCRIPTINLINE>"?"</JAVASCRIPTINLINE></JAVASCRIPT></SPLITINLINE>,
     and the <SPLITINLINE><SCHEME>constant symbols</SCHEME><JAVASCRIPT>strings</JAVASCRIPT></SPLITINLINE> (which need to be recognized for
-    data-base indexing, section<SPACE/>4.4.4.5<!--<REF NAME="sec:query-db"/>-->) are just the
+    data-base indexing, section<SPACE/><REF NAME="sec:query-db"/>) are just the
     <SPLITINLINE><SCHEME>symbols</SCHEME><JAVASCRIPT>strings</JAVASCRIPT></SPLITINLINE>.
 
     <SNIPPET EVAL="no">
@@ -2075,7 +2075,7 @@ function is_constant_string(exp) {
 
   <TEXT>
     Unique variables are constructed during rule application
-    (in section<SPACE/>4.4.4.4<!--<REF NAME="sec:query-unify"/>-->) by means of
+    (in section<SPACE/><REF NAME="sec:query-unify"/>) by means of
     the following
     <SPLITINLINE><SCHEME>procedures</SCHEME><JAVASCRIPT>functions</JAVASCRIPT></SPLITINLINE>.  The unique identifier for a rule
     application is a number, which is incremented each time a rule is
@@ -2136,10 +2136,9 @@ function contract_question_mark(variable) {
   </TEXT>
 
       <SUBSUBSECTION>
-  <NAME>4.4.4.8<SPACE/><SPACE/>Frames and Bindings</NAME>
-      </SUBSUBSECTION>
-      
+  <NAME>Frames and Bindings</NAME>
   <LABEL NAME="sec:query-bindings"/>
+      </SUBSUBSECTION>
 
   <TEXT>
     <INDEX>query interpreter<SUBINDEX>frame|(</SUBINDEX></INDEX>
@@ -2190,7 +2189,7 @@ function extend(variable, value, frame) {
     <SPLITINLINE><SCHEME><SCHEMEINLINE>simple-query</SCHEMEINLINE></SCHEME><JAVASCRIPT><JAVASCRIPTINLINE>simple_query</JAVASCRIPTINLINE></JAVASCRIPT></SPLITINLINE>
     and <SCHEMEINLINE>disjoin</SCHEMEINLINE>
     <SPLITINLINE><SCHEME>procedures</SCHEME><JAVASCRIPT>functions</JAVASCRIPT></SPLITINLINE>
-    (section<SPACE/>4.4.4.2<!--<REF NAME="sec:query-eval"/>-->) are implemented using
+    (section<SPACE/><REF NAME="sec:query-eval"/>) are implemented using
     explicit
     <SPLITINLINE><SCHEME><SCHEMEINLINE>delay</SCHEMEINLINE></SCHEME><JAVASCRIPT>delay</JAVASCRIPT></SPLITINLINE>
     operations, rather than being defined as follows:

--- a/xml/chapter5/section4/subsection3.xml
+++ b/xml/chapter5/section4/subsection3.xml
@@ -194,7 +194,7 @@
   transformers such as <SCHEMEINLINE>cond-&gt;if</SCHEMEINLINE> are available as machine
   operations.<FOOTNOTE>This isn<APOS/>t really cheating.  In an actual
     implementation built from scratch, we would use our explicit-control
-    evaluator to interpret a <SPLIT><SCHEME>Scheme</SCHEME><JAVASCRIPT>JavaScript</JAVASCRIPT></SPLIT> program that performs source-level
+    evaluator to interpret a <SPLITINLINE><SCHEME>Scheme</SCHEME><JAVASCRIPT>JavaScript</JAVASCRIPT></SPLITINLINE> program that performs source-level
     transformations <SPLITINLINE><SCHEME><SCHEMEINLINE>like cond-&gt;if</SCHEMEINLINE></SCHEME><JAVASCRIPT><JAVASCRIPTINLINE></JAVASCRIPTINLINE></JAVASCRIPT></SPLITINLINE> in a syntax phase that runs before
     execution.</FOOTNOTE>
   <LABEL NAME="ex:derived-expressions"/>


### PR DESCRIPTION
1. using `<SPLITINLINE>` for `<FOOTNOTE>` comparison between versions
!!! future editors need to take note:
use `<SPLITINLINE>` instead of `<SPLIT>` for the footnotes, such that the footnote number can be displayed within one line inside the paragraph in the split version

2. `<SUBSUBSECTION>`
- removed hardcoded subsubsection number (e.g. 4.4.4.1,etc.)
- removed hardcoded subsubsection references and activated reference using `<REF>` tag
- moved `<LABEL>` inside `<SUBSUBSECTION>` tags

!!! future editors need to take note:
pls include `<LABEL>` tag for subsubsections within the `<SUBSUBSECTION>` tags so that it can be clearer that it is a subsubsection label and our function will be able to recognise it as a subsubsection label too.
