### PR TITLE
Deploy to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,57 @@
+on:
+  push:
+    branches:
+      - master
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@master
+      - name: Use Node.js
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: '12'
+      - name: Install pandoc
+        run: |
+          URL="https://github.com/jgm/pandoc/releases/latest"
+          PANDOCPAGE="$(wget $URL -q -O -)"
+          DEBURL="$(echo $PANDOCPAGE | grep -oP '"([^"]+.deb)"')"
+          DEBURL="${DEBURL:1:-1}"
+          URL="http://github.com$DEBURL"
+          wget $URL -O /tmp/pandoc.deb
+          sudo dpkg -i /tmp/pandoc.deb
+        # The above script adapted from https://gist.github.com/rossant/8b751a15d71d6d9403a8
+      - name: Install TeX Live and Inkscape
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y texlive texlive-fonts-extra latexmk
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Fetch Yarn dependencies
+        run: |
+          yarn install
+      - name: Build
+        run: |
+          set -euxo pipefail
+          yarn run pdf || (cat latex_pdf/sicpjs.log && false)
+          yarn run epub
+          yarn run web
+          yarn run split
+          yarn run js
+      - name: Package
+        run: |
+          yarn run prepare
+          find docs_out -name .gitignore -delete -print
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs_out


### PR DESCRIPTION
Here is the result of my last test run: https://source-academy.github.io/sicp/

Sampled a few pages, looks correct.

---

On a side note, it seems the book no longer builds correctly on newer versions of TeX Live (2019, 2020), which was why I was having some trouble earlier. I went to seek #latex (on Freenode) for help and I realised that the current build script runs pdfTeX in non-stop mode (i.e. ignoring errors...):

```
latexmk -silent -pdf -pdflatex="pdflatex --synctex=1" -f ${OUTPUT_FILE}
                                                      ^^
```

If there is time, it may be good to turn off `-f` and then fixing the errors that result, so that the book is buildable with newer versions of TeX Live.