### PR TITLE
Fixed a stack overflow on Chrome in 1.3.1 integral(cube, 0, 1, 0.001)

### DIFF
--- a/xml/chapter1/section3/subsection1.xml
+++ b/xml/chapter1/section3/subsection1.xml
@@ -549,6 +549,9 @@ integral(cube, 0, 1, 0.01);
       <JAVASCRIPT>
 integral(cube, 0, 1, 0.001);
       </JAVASCRIPT>
+      <JAVASCRIPT_RUN>
+integral(cube, 0, 1, 0.002);
+      </JAVASCRIPT_RUN>
       <JAVASCRIPT_OUTPUT>
 0.249999875000001	  
       </JAVASCRIPT_OUTPUT>

--- a/xml/chapter1/section3/subsection1.xml
+++ b/xml/chapter1/section3/subsection1.xml
@@ -550,6 +550,7 @@ integral(cube, 0, 1, 0.01);
 integral(cube, 0, 1, 0.001);
       </JAVASCRIPT>
       <JAVASCRIPT_RUN>
+// dare to try 0.001 with in browser?
 integral(cube, 0, 1, 0.002);
       </JAVASCRIPT_RUN>
       <JAVASCRIPT_OUTPUT>


### PR DESCRIPTION
On Chrome, the code integral(cube, 0, 1, 0.001) results in the error

```
Line 10: RangeError: Maximum call stack size exceeded
```

when run. If changed to integral(cube, 0, 1, 0.002) it works. Strangely, if run with 0.002 and then changed back to 0.001 it work.
On Firefox 0.001 works out of the box.

So, my suggestion is to add a JAVASCRIPT_RUN block to run it with 0.002 while still retaining the more illustrative 0.001 in the text.
