### PR TITLE
uses latex for the figure in 5.5.1

### DIFF
--- a/xml/chapter5/section5/subsection1.xml
+++ b/xml/chapter5/section5/subsection1.xml
@@ -88,6 +88,7 @@
     <EM>code
     generator</EM>:
     <!--  \indcode*{compile} -->
+    <!-- FIXME: include blocks and return statements -->
     <SNIPPET EVAL="no">
       <NAME>compile</NAME>
       <SCHEME>
@@ -378,7 +379,19 @@ $seq_2$
       <FIGURE src="img_original/preserving_table.svg"></FIGURE>
     </SCHEME>
     <JAVASCRIPT>
-      <FIGURE src="img_javascript/preserving_table.svg"></FIGURE>
+    <LATEX>
+      \[
+      {
+      \begin{array}{l|l|l|l}
+\textit{seq}_1 &amp; \texttt{save(}\textit{reg}_1\texttt{)}    &amp; \texttt{save(}\textit{reg}_2\texttt{)}      &amp; \texttt{save(}\textit{reg}_2\texttt{)}    \\
+\textit{seq}_2 &amp; \textit{seq}_1                            &amp; \textit{seq}_1                              &amp; \texttt{save(}\textit{reg}_1\texttt{)}    \\
+               &amp; \texttt{restore(}\textit{reg}_1\texttt{)} &amp; \texttt{restore(}\textit{reg}_2\texttt{)}   &amp; \textit{seq}_1                            \\
+               &amp; \textit{seq}_2                            &amp; \textit{seq}_2                              &amp; \texttt{restore(}\textit{reg}_1\texttt{)} \\
+               &amp;                                           &amp;                                             &amp; \texttt{restore(}\textit{reg}_2\texttt{)} \\
+               &amp;                                           &amp;                                             &amp; \textit{seq}_2                            
+\end{array}}
+      \]
+    </LATEX>
     </JAVASCRIPT>
   </SPLIT>
   <!-- \begin{Stabular}{c|c|c|c} -->


### PR DESCRIPTION
I think LaTeX is better for such formula-looking stuff, instead of SVG. MathJax does a good job with it. Will be easier to handle in the final stages of typesetting, too.