### PR TITLE
2.1.4: Remove unmatched open parentheses

### DIFF
--- a/xml/chapter2/section1/subsection4.xml
+++ b/xml/chapter2/section1/subsection4.xml
@@ -342,7 +342,7 @@ print_interval(sub_interval(make_interval(0, 1),
       whose width is
       <LATEX>\[(U(i_1) + U(i_2) - (L(i_1) + L(i_2)))/2\]</LATEX>
       <LATEX>\[= (U(i_1) - L(i_1))/2 + (U(i_2) - L(i_2))/2\]</LATEX>
-      <LATEX>\[= (W(i_1) + W(i_2)\]</LATEX>
+      <LATEX>\[= W(i_1) + W(i_2)\]</LATEX>
       The argument for subtraction is similar.
       <P/>
       The widths of the result of multiplying intervals does not have


### PR DESCRIPTION
The last step of formula derivation has an invalid open parenthesis in solution to Exercise 2.9