### PR TITLE
Fix fig 2.1

### DIFF
--- a/static/img_original/ch2-Z-G-6.svg
+++ b/static/img_original/ch2-Z-G-6.svg
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<?xml-stylesheet href="https://fonts.googleapis.com/css?family=Inconsolata&display=swap" type="text/css"?><svg
+<svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -9,39 +7,35 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="SICP Figure 2.1.svg"
    preserveAspectRatio="xMinYMin meet"
-   viewBox="0 0 450.54501 350.15381"
+   viewBox="0 0 521.0401 349.61789"
    id="svg4113"
    style="display:inline"
    version="1.1"
-   sodipodi:docname="ch2-Z-G-6.svg"
-   width="450.54501"
-   height="350.15381"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+   width="521.0401"
+   height="349.61789">
   <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="3192"
-     inkscape:window-height="1725"
-     id="namedview37"
+     inkscape:current-layer="svg4113"
+     inkscape:cy="168.12265"
+     inkscape:cx="219.68633"
+     inkscape:zoom="1.3955341"
+     inkscape:snap-page="true"
+     inkscape:snap-object-midpoints="true"
+     scale-x="1"
      showgrid="false"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0"
-     inkscape:zoom="2.1405896"
-     inkscape:cx="248.12815"
-     inkscape:cy="170.2841"
-     inkscape:window-x="0"
-     inkscape:window-y="26"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg4113" />
+     id="namedview36"
+     inkscape:window-height="480"
+     inkscape:window-width="640"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
   <title
      id="title4565">SICP Figure 2.1</title>
   <defs
@@ -81,9 +75,9 @@
             <rdf:li>make-rat</rdf:li>
             <rdf:li>numer</rdf:li>
             <rdf:li>denom</rdf:li>
-            <rdf:li>cons</rdf:li>
-            <rdf:li>car</rdf:li>
-            <rdf:li>cdr</rdf:li>
+            <rdf:li>pair</rdf:li>
+            <rdf:li>head</rdf:li>
+            <rdf:li>tail</rdf:li>
           </rdf:Bag>
         </dc:subject>
       </cc:Work>
@@ -106,9 +100,9 @@
         <dc:title>SICP Figure 2.1</dc:title>
       </cc:Work>
     </rdf:RDF>
-  </metadata><rect width="100%" height="100%" fill="white"/>
+  </metadata>
   <g
-     transform="matrix(0.8,0,0,0.8,-68.154617,-62.979943)"
+     transform="matrix(0.8,0,0,0.8,-32.628144,-62.979943)"
      id="layer6"
      style="display:inline">
     <rect
@@ -119,7 +113,7 @@
        x="123.37505"
        y="79.130798"
        id="rect4103"
-       style="display:inline;fill:#e8e8e8;fill-opacity:1;stroke:#383838;stroke-width:0.81173867;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+       style="display:inline;fill:#e8e8e8;fill-opacity:1;stroke:#383838;stroke-width:0.811739;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <rect
        width="314.99969"
        height="47.727226"
@@ -128,7 +122,7 @@
        x="209.28406"
        y="193.67615"
        id="rect4103-6"
-       style="display:inline;fill:#e8e8e8;fill-opacity:1;stroke:#383838;stroke-width:0.81173867;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+       style="display:inline;fill:#e8e8e8;fill-opacity:1;stroke:#383838;stroke-width:0.811739;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <rect
        width="334.09058"
        height="47.727226"
@@ -137,7 +131,7 @@
        x="199.73862"
        y="308.2215"
        id="rect4103-5"
-       style="display:inline;fill:#e8e8e8;fill-opacity:1;stroke:#383838;stroke-width:0.81173867;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+       style="display:inline;fill:#e8e8e8;fill-opacity:1;stroke:#383838;stroke-width:0.811739;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <rect
        width="238.63612"
        height="47.727226"
@@ -146,132 +140,123 @@
        x="247.46584"
        y="422.76682"
        id="rect4103-69"
-       style="display:inline;fill:#e8e8e8;fill-opacity:1;stroke:#383838;stroke-width:0.81173867;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+       style="display:inline;fill:#e8e8e8;fill-opacity:1;stroke:#383838;stroke-width:0.811739;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   </g>
+  <text
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:19.8545px;line-height:125%;font-family:'Linux Biolinum O';-inkscape-font-specification:'Linux Biolinum O';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#383838;fill-opacity:1;stroke:none;stroke-width:0.8"
+     xml:space="preserve"
+     id="text6868"
+     y="24.8974"
+     x="260.68988"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata;stroke-width:0.8"
+       id="tspan6870"
+       y="24.8974"
+       x="260.68988">Programs that use rational numbers</tspan></text>
+  <text
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:19.8545px;line-height:125%;font-family:'Linux Biolinum O';-inkscape-font-specification:'Linux Biolinum O';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#383838;fill-opacity:1;stroke:none;stroke-width:0.8"
+     xml:space="preserve"
+     id="text6872"
+     y="70.579155"
+     x="260.03531"><tspan
+       id="tspan6874"
+       y="70.579155"
+       x="260.03531"
+       style="stroke-width:0.8">Rational numbers in problem domain</tspan></text>
+  <text
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:19.8545px;line-height:125%;font-family:'Linux Biolinum O';-inkscape-font-specification:'Linux Biolinum O';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#383838;fill-opacity:1;stroke:none;stroke-width:0.8"
+     xml:space="preserve"
+     id="text6876"
+     y="116.39731"
+     x="261.56259"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata;stroke-width:0.8"
+       id="tspan6878"
+       y="116.39731"
+       x="261.56259">add_rat  sub_rat  ...</tspan></text>
+  <text
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:19.8545px;line-height:125%;font-family:'Linux Biolinum O';-inkscape-font-specification:'Linux Biolinum O';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#383838;fill-opacity:1;stroke:none;stroke-width:0.8"
+     xml:space="preserve"
+     id="text6880"
+     y="162.21544"
+     x="260.03531"><tspan
+       id="tspan6882"
+       y="162.21544"
+       x="260.03531"
+       style="stroke-width:0.8">Rational numbers as numerators and denominators</tspan></text>
+  <text
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:19.8545px;line-height:125%;font-family:'Linux Biolinum O';-inkscape-font-specification:'Linux Biolinum O';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#383838;fill-opacity:1;stroke:none;stroke-width:0.8"
+     xml:space="preserve"
+     id="text6884"
+     y="208.03358"
+     x="260.03531"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata;stroke-width:0.8"
+       id="tspan6886"
+       y="208.03358"
+       x="260.03531">make_rat  numer  denom</tspan></text>
+  <text
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:19.8545px;line-height:125%;font-family:'Linux Biolinum O';-inkscape-font-specification:'Linux Biolinum O';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#383838;fill-opacity:1;stroke:none;stroke-width:0.8"
+     xml:space="preserve"
+     id="text6888"
+     y="253.85172"
+     x="260.03531"><tspan
+       id="tspan6890"
+       y="253.85172"
+       x="260.03531"
+       style="stroke-width:0.8">Rational numbers as pairs</tspan></text>
+  <text
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:19.8545px;line-height:125%;font-family:'Linux Biolinum O';-inkscape-font-specification:'Linux Biolinum O';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#383838;fill-opacity:1;stroke:none;stroke-width:0.8"
+     xml:space="preserve"
+     id="text6892"
+     y="299.66986"
+     x="260.03531"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata;stroke-width:0.8"
+       id="tspan6894"
+       y="299.66986"
+       x="260.03531">pair  head  tail</tspan></text>
+  <text
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:19.8545px;line-height:125%;font-family:'Linux Biolinum O';-inkscape-font-specification:'Linux Biolinum O';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#383838;fill-opacity:1;stroke:none;stroke-width:0.8"
+     xml:space="preserve"
+     id="text6896"
+     y="345.48801"
+     x="260.03531"><tspan
+       id="tspan6898"
+       y="345.48801"
+       x="260.03531"
+       style="stroke-width:0.8">However pairs are implemented</tspan></text>
   <g
-     transform="matrix(0.8,0,0,0.8,-68.154617,-62.979943)"
-     id="layer3"
-     style="display:inline">
-    <text
-       x="366.64755"
-       y="109.84668"
-       id="text6868"
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24.8181572px;line-height:125%;font-family:'Linux Biolinum O';-inkscape-font-specification:'Linux Biolinum O';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#383838;fill-opacity:1;stroke:none"><tspan
-         x="366.64755"
-         y="109.84668"
-         id="tspan6870"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata">Programs that use rational numbers</tspan></text>
-    <text
-       x="365.82935"
-       y="166.94888"
-       id="text6872"
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24.8181572px;line-height:125%;font-family:'Linux Biolinum O';-inkscape-font-specification:'Linux Biolinum O';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#383838;fill-opacity:1;stroke:none"><tspan
-         x="365.82935"
-         y="166.94888"
-         id="tspan6874">Rational numbers in problem domain</tspan></text>
-    <text
-       x="367.73843"
-       y="224.22156"
-       id="text6876"
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24.8181572px;line-height:125%;font-family:'Linux Biolinum O';-inkscape-font-specification:'Linux Biolinum O';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#383838;fill-opacity:1;stroke:none"><tspan
-         x="367.73843"
-         y="224.22156"
-         id="tspan6878"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata">add-rat  sub-rat  ...</tspan></text>
-    <text
-       x="365.82935"
-       y="281.49423"
-       id="text6880"
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24.8181572px;line-height:125%;font-family:'Linux Biolinum O';-inkscape-font-specification:'Linux Biolinum O';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#383838;fill-opacity:1;stroke:none"><tspan
-         x="365.82935"
-         y="281.49423"
-         id="tspan6882">Rational numbers as numerators and denominators</tspan></text>
-    <text
-       x="365.82935"
-       y="338.76691"
-       id="text6884"
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24.8181572px;line-height:125%;font-family:'Linux Biolinum O';-inkscape-font-specification:'Linux Biolinum O';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#383838;fill-opacity:1;stroke:none"><tspan
-         x="365.82935"
-         y="338.76691"
-         id="tspan6886"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata">make-rat  numer  denom</tspan></text>
-    <text
-       x="365.82935"
-       y="396.03958"
-       id="text6888"
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24.8181572px;line-height:125%;font-family:'Linux Biolinum O';-inkscape-font-specification:'Linux Biolinum O';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#383838;fill-opacity:1;stroke:none"><tspan
-         x="365.82935"
-         y="396.03958"
-         id="tspan6890">Rational numbers as pairs</tspan></text>
-    <text
-       x="365.82935"
-       y="453.31226"
-       id="text6892"
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24.8181572px;line-height:125%;font-family:'Linux Biolinum O';-inkscape-font-specification:'Linux Biolinum O';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#383838;fill-opacity:1;stroke:none"><tspan
-         x="365.82935"
-         y="453.31226"
-         id="tspan6894"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata">cons  car  cdr</tspan></text>
-    <text
-       x="365.82935"
-       y="510.58493"
-       id="text6896"
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24.8181572px;line-height:125%;font-family:'Linux Biolinum O';-inkscape-font-specification:'Linux Biolinum O';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#383838;fill-opacity:1;stroke:none"><tspan
-         x="365.82935"
-         y="510.58493"
-         id="tspan6898">However pairs are implemented</tspan></text>
-  </g>
-  <g
-     transform="matrix(0.8,0,0,0.8,-68.154617,-62.979943)"
+     transform="matrix(0.8,0,0,0.8,-32.628144,-62.979943)"
      id="layer5"
      style="display:inline">
     <path
-       d="m 610.19275,102.92138 h 38.18178"
+       d="m 610.19276,102.92138 h 75.64259"
        id="path4105"
-       style="fill:none;stroke:#383838;stroke-width:0.81173867;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:connector-curvature="0" />
+       style="fill:none;stroke:#383838;stroke-width:0.811739;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       d="M 85.193271,103.06259 H 123.37505"
+       d="m 47.0352,103.06259 h 76.33984"
        id="path4105-9"
-       style="display:inline;fill:none;stroke:#383838;stroke-width:0.81173867;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:connector-curvature="0" />
+       style="display:inline;fill:none;stroke:#383838;stroke-width:0.811739;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       d="M 524.28375,217.60792 H 648.37453"
+       d="M 524.28377,217.60792 H 685.83536"
        id="path4105-0"
-       style="display:inline;fill:none;stroke:#383838;stroke-width:0.81173867;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:connector-curvature="0" />
+       style="display:inline;fill:none;stroke:#383838;stroke-width:0.811739;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       d="M 85.193271,217.60792 H 209.28406"
+       d="M 47.035212,217.60792 H 209.28407"
        id="path4105-9-9"
-       style="display:inline;fill:none;stroke:#383838;stroke-width:0.81173867;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:connector-curvature="0" />
+       style="display:inline;fill:none;stroke:#383838;stroke-width:0.811739;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       d="M 533.82919,332.15326 H 648.37453"
+       d="M 533.8292,332.15326 H 685.83534"
        id="path4105-3"
-       style="display:inline;fill:none;stroke:#383838;stroke-width:0.81173867;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:connector-curvature="0" />
+       style="display:inline;fill:none;stroke:#383838;stroke-width:0.811739;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       d="M 85.193271,332.15326 H 199.73861"
+       d="M 47.035211,332.15326 H 199.73862"
        id="path4105-9-7"
-       style="display:inline;fill:none;stroke:#383838;stroke-width:0.81173867;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:connector-curvature="0" />
+       style="display:inline;fill:none;stroke:#383838;stroke-width:0.811739;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       d="M 486.10197,446.6986 H 648.37453"
+       d="M 486.10195,446.6986 H 685.83531"
        id="path4105-7"
-       style="display:inline;fill:none;stroke:#383838;stroke-width:0.81173867;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:connector-curvature="0" />
+       style="display:inline;fill:none;stroke:#383838;stroke-width:0.811739;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       d="M 85.193271,446.6986 H 247.46584"
+       d="M 47.035213,446.6986 H 247.46585"
        id="path4105-9-2"
-       style="display:inline;fill:none;stroke:#383838;stroke-width:0.81173867;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:connector-curvature="0" />
+       style="display:inline;fill:none;stroke:#383838;stroke-width:0.81174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>


### PR DESCRIPTION
A simple fix for the cropping on the figure. See screenshot. Seems to not affect Chrome. This is caused by the viewport being too small on the original svg (can be confirmed in inkscape). It now has a 5px border around the sides. The svg was also converted from inkscape svg to a generic svg.

![2020-08-01-222228_1889x937_scrot](https://user-images.githubusercontent.com/10473184/89103609-7ec3b680-d402-11ea-9409-409d1e493e39.png)

