### PR TITLE
Fix typo "terminate terminates" -> "terminate"

### DIFF
--- a/xml/chapter1/section1/subsection7.xml
+++ b/xml/chapter1/section1/subsection7.xml
@@ -674,7 +674,7 @@ function sqrt_iter(guess, x) {
       <P/>
       On the other hand, for very large values, rounding errors might make
       the algorithm fail to ever get close enough to the square root, in which
-      case it will not terminate terminates. 
+      case it will not terminate.
       <P/>
       The following program alleviates the problem by replacing an absolute
       tolerance with a relative tolerance.


### PR DESCRIPTION
Seen [here](https://source-academy.github.io/sicp/chapters/1.1.7.html#ex_1.7).