### PR TITLE
Fix typo in 3.3.1

### DIFF
--- a/xml/chapter3/section3/subsection1.xml
+++ b/xml/chapter3/section3/subsection1.xml
@@ -64,7 +64,7 @@
         <FIGURE>
           <FIGURE src="img_javascript/ch3-Z-G-13.svg"></FIGURE>
           <CAPTION>
-	    Lists
+	    Lists <SCHEMEINLINE>x</SCHEMEINLINE>:
 	    <JAVASCRIPTINLINE>list(list("a", "b"), "c", "d")</JAVASCRIPTINLINE>
 	    and <SCHEMEINLINE>y</SCHEMEINLINE>:
 	    <JAVASCRIPTINLINE>list("e", "f")</JAVASCRIPTINLINE>.
@@ -212,7 +212,7 @@
     <SPLITINLINE>
       <SCHEME><SCHEMEINLINE>((a b) c d)</SCHEMEINLINE></SCHEME>
       <JAVASCRIPT>
-	<JAVASCRIPTINLINE>list(list("a", "b"), "c")</JAVASCRIPTINLINE>
+	<JAVASCRIPTINLINE>list(list("a", "b"), "c", "d")</JAVASCRIPTINLINE>
       </JAVASCRIPT>
     </SPLITINLINE>
     and <SCHEMEINLINE>y</SCHEMEINLINE> to the list


### PR DESCRIPTION
Changed [paragraph 3 of Section 3.3.1](https://source-academy.github.io/sicp/chapters/3.3.1.html#p3) and the caption of Figure 3.12 to be consistent with what the Figure depicts.

The list `x` is `list(list("a", "b"), "c", "d")`, not `list(list("a", "b"), "c")`