### PR TITLE
Fix exercise 3.58 typo and add solution

### DIFF
--- a/xml/chapter3/section5/subsection2.xml
+++ b/xml/chapter3/section5/subsection2.xml
@@ -1149,7 +1149,7 @@ const S = pair(1, () => merge($\langle ??\rangle$, $\langle ??\rangle$));
       <JAVASCRIPT>
 function expand(num, den, radix) {
     return pair(quotient(num * radix, den),
-                expand((num * radix) % den, den, radix));
+                () => expand((num * radix) % den, den, radix));
 }
       </JAVASCRIPT>
     </SNIPPET>
@@ -1187,6 +1187,44 @@ function expand(num, den, radix) {
 	<JAVASCRIPTINLINE>expand(3, 8, 10)</JAVASCRIPTINLINE>?
       </JAVASCRIPT>
     </SPLITINLINE>
+    <SOLUTION>
+    This function will produce a infinite stream of numbers which represent the results of 
+    <SPLITINLINE>
+      <JAVASCRIPT>
+  <JAVASCRIPTINLINE>num / den</JAVASCRIPTINLINE> 
+      </JAVASCRIPT>
+    </SPLITINLINE>
+    in base-
+    <SPLITINLINE>
+      <JAVASCRIPT>
+  <JAVASCRIPTINLINE>radix</JAVASCRIPTINLINE>
+      </JAVASCRIPT>
+    </SPLITINLINE>
+    system.
+    <SPLITINLINE>
+      <JAVASCRIPT>
+  <JAVASCRIPTINLINE>expand(1, 7, 10)</JAVASCRIPTINLINE>
+      </JAVASCRIPT>
+    </SPITINLINE>
+    will produce a infinite stream of numbers:
+    <SPITINLINE>
+      <JAVASCRIPT>
+  <JAVASCRIPTINLINE>1, 4, 2, 8, 5, 7, 1, 4, 2, 8, 5, 7...</JAVASCRIPTINLINE>
+      </JAVASCRIPT>
+    </SPITINLINE>
+    . While 
+    <SPITINLINE>
+      <JAVASCRIPT>
+  <JAVASCRIPTINLINE>expand(3, 8, 10)</JAVASCRIPTINLINE>
+      </JAVASCRIPT>
+    </SPITINLINE>
+    will produce a stream of numbers:
+    <SPITINLINE>
+      <JAVASCRIPT>
+  <JAVASCRIPTINLINE>3, 7, 5, 0, 0, 0, 0 ...</JAVASCRIPTINLINE>
+      </JAVASCRIPT>
+    </SPITINLINE>
+    </SOLUTION>
   </EXERCISE>
 
   <EXERCISE>

--- a/xml/chapter3/section5/subsection2.xml
+++ b/xml/chapter3/section5/subsection2.xml
@@ -1189,29 +1189,13 @@ function expand(num, den, radix) {
     </SPLITINLINE>
     <SOLUTION>
     This function will produce a infinite stream of numbers which represent the results of 
-    <SPLITINLINE>
-      <JAVASCRIPT>
-  <JAVASCRIPTINLINE>num / den</JAVASCRIPTINLINE> 
-      </JAVASCRIPT>
-    </SPLITINLINE>
+    <JAVASCRIPTINLINE>num / den</JAVASCRIPTINLINE> 
     in base-
-    <SPLITINLINE>
-      <JAVASCRIPT>
-  <JAVASCRIPTINLINE>radix</JAVASCRIPTINLINE>
-      </JAVASCRIPT>
-    </SPLITINLINE>
+    <JAVASCRIPTINLINE>radix</JAVASCRIPTINLINE>
     system.
-    <SPLITINLINE>
-      <JAVASCRIPT>
-  <JAVASCRIPTINLINE>expand(1, 7, 10)</JAVASCRIPTINLINE>
-      </JAVASCRIPT>
-    </SPITINLINE>
+    <JAVASCRIPTINLINE>expand(1, 7, 10)</JAVASCRIPTINLINE>
     will produce a infinite stream of numbers: 1, 4, 2, 8, 5, 7, 1, 4, 2, 8, 5, 7... While 
-    <SPITINLINE>
-      <JAVASCRIPT>
-  <JAVASCRIPTINLINE>expand(3, 8, 10)</JAVASCRIPTINLINE>
-      </JAVASCRIPT>
-    </SPITINLINE>
+    <JAVASCRIPTINLINE>expand(3, 8, 10)</JAVASCRIPTINLINE>
     will produce a stream of numbers: 3, 7, 5, 0, 0, 0, 0 ...
     </SOLUTION>
   </EXERCISE>

--- a/xml/chapter3/section5/subsection2.xml
+++ b/xml/chapter3/section5/subsection2.xml
@@ -1206,24 +1206,13 @@ function expand(num, den, radix) {
   <JAVASCRIPTINLINE>expand(1, 7, 10)</JAVASCRIPTINLINE>
       </JAVASCRIPT>
     </SPITINLINE>
-    will produce a infinite stream of numbers:
-    <SPITINLINE>
-      <JAVASCRIPT>
-  <JAVASCRIPTINLINE>1, 4, 2, 8, 5, 7, 1, 4, 2, 8, 5, 7...</JAVASCRIPTINLINE>
-      </JAVASCRIPT>
-    </SPITINLINE>
-    . While 
+    will produce a infinite stream of numbers: 1, 4, 2, 8, 5, 7, 1, 4, 2, 8, 5, 7... While 
     <SPITINLINE>
       <JAVASCRIPT>
   <JAVASCRIPTINLINE>expand(3, 8, 10)</JAVASCRIPTINLINE>
       </JAVASCRIPT>
     </SPITINLINE>
-    will produce a stream of numbers:
-    <SPITINLINE>
-      <JAVASCRIPT>
-  <JAVASCRIPTINLINE>3, 7, 5, 0, 0, 0, 0 ...</JAVASCRIPTINLINE>
-      </JAVASCRIPT>
-    </SPITINLINE>
+    will produce a stream of numbers: 3, 7, 5, 0, 0, 0, 0 ...
     </SOLUTION>
   </EXERCISE>
 


### PR DESCRIPTION
fix a possible typo. Since the exercise said it is a stream, I think there is a typo here. This is what the web edition (built on my laptop) looks like after fixing that typo and adding solution
![image](https://user-images.githubusercontent.com/35390703/97125619-74018f00-176f-11eb-9ab2-8ec7e6a76c77.png)
