### PR TITLE
removes \OptionalPar

### DIFF
--- a/xml/chapter4/section1/subsection2.xml
+++ b/xml/chapter4/section1/subsection2.xml
@@ -1322,7 +1322,7 @@ function function_declaration_body(component) {
 	The syntax predicate
 	<JAVASCRIPTINLINE>is_declaration</JAVASCRIPTINLINE>
 	returns true for all three kinds of declarations.
-      <INDEX><DECLARATATION>is_declaration</DECLARATATION></INDEX>
+      <INDEX><DECLARATION>is_declaration</DECLARATION></INDEX>
 	<SNIPPET PAGE="370">
 	      <NAME>definition</NAME>
 	      <REQUIRES>tagged_list</REQUIRES>

--- a/xml/chapter5/section1/subsection5.xml
+++ b/xml/chapter5/section1/subsection5.xml
@@ -15,14 +15,14 @@
     <SPLITINLINE>
       <SCHEME><SCHEMEINLINE>(reg ^register-name^)</SCHEMEINLINE></SCHEME>
       <JAVASCRIPT>
-	<JAVASCRIPTINLINE>reg(</JAVASCRIPTINLINE><LATEXINLINE>$\OptionalPar{register-name}$</LATEXINLINE><JAVASCRIPTINLINE>)</JAVASCRIPTINLINE>
+	<JAVASCRIPTINLINE>reg(</JAVASCRIPTINLINE><LATEXINLINE>$\textit{register-name}$</LATEXINLINE><JAVASCRIPTINLINE>)</JAVASCRIPTINLINE>
       </JAVASCRIPT>
     </SPLITINLINE>
     or
     <SPLITINLINE>
       <SCHEME><SCHEMEINLINE>(const ^constant-value^)</SCHEMEINLINE>.</SCHEME>
       <JAVASCRIPT>
-	<JAVASCRIPTINLINE>constant(</JAVASCRIPTINLINE><LATEXINLINE>$\OptionalPar{constant-value}$</LATEXINLINE><JAVASCRIPTINLINE>)</JAVASCRIPTINLINE>.
+	<JAVASCRIPTINLINE>constant(</JAVASCRIPTINLINE><LATEXINLINE>$\textit{constant-value}$</LATEXINLINE><JAVASCRIPTINLINE>)</JAVASCRIPTINLINE>.
       </JAVASCRIPT>
       </SPLITINLINE>
   </TEXT>
@@ -61,19 +61,19 @@
 (goto (label ^label-name^))
       </SCHEME>
       <JAVASCRIPT>
-assign($\OptionalPar{register-name}$, reg($\OptionalPar{register-name}$))
+assign($register$-$name$, reg($register$-$name$))
 
-assign($\OptionalPar{register-name}$, constant($\OptionalPar{constant-value}$))
+assign($register$-$name$, constant($constant$-$value$))
 
-assign($\OptionalPar{register-name}$, list(op($\OptionalPar{operation-name}$), $\OptionalPar[1]{input}$, $\ldots$, $\OptionalPar[n]{input}$))
+assign($register$-$name$, list(op($operation$-$name$), $input_1$, $\ldots$, $input_n$))
 
-perform(list(op($\OptionalPar{operation-name}$), $\OptionalPar[1]{input}$, $\ldots$, $\OptionalPar[n]{input}$))
+perform(list(op($operation$-$name$), $input_1$, $\ldots$, $input_n$))
 
-test(list(op($\OptionalPar{operation-name}$), $\OptionalPar[1]{input}$, $\ldots$, $\OptionalPar[n]{input}$))
+test(list(op($operation$-$name$), $input_1$, $\ldots$, $input_n$))
 
-branch(label($\OptionalPar{label-name}$))
+branch(label($label$-$name$))
 
-go_to(label($\OptionalPar{label-name}$))
+go_to(label($label$-$name$))
       </JAVASCRIPT>
     </SNIPPET>
   </TEXT>
@@ -88,9 +88,9 @@ go_to(label($\OptionalPar{label-name}$))
 (goto (reg ^register-name^))
       </SCHEME>
       <JAVASCRIPT>
-assign($\OptionalPar{register-name}$, label($\OptionalPar{label-name}$))
+assign($register$-$name$, label($label$-$name$))
 
-go_to(reg($\OptionalPar{register-name}$))
+go_to(reg($register$-$name$))
       </JAVASCRIPT>
     </SNIPPET>
   </TEXT>
@@ -107,9 +107,9 @@ go_to(reg($\OptionalPar{register-name}$))
 (restore ^register-name^)
       </SCHEME>
       <JAVASCRIPT>
-save($\OptionalPar{register-name}$)
+save($register$-$name$)
 
-restore($\OptionalPar{register-name}$)
+restore($register$-$name$)
       </JAVASCRIPT>
     </SNIPPET>
   </TEXT>
@@ -121,10 +121,10 @@ restore($\OptionalPar{register-name}$)
     The only kind of
     <SPLITINLINE>
       <SCHEME>
-	<LATEXINLINE>$\langle constant-value \rangle$</LATEXINLINE>
+	<LATEXINLINE>$\langle \textit{constant-value} \rangle$</LATEXINLINE>
       </SCHEME>
       <JAVASCRIPT>
-	<LATEXINLINE>$\OptionalPar{constant-value}$</LATEXINLINE>
+	<LATEXINLINE>$\textit{constant-value}$</LATEXINLINE>
       </JAVASCRIPT>
     </SPLITINLINE>
     we have seen so far is a number, but later we will use

--- a/xml/chapter5/section2/section2.xml
+++ b/xml/chapter5/section2/section2.xml
@@ -37,9 +37,7 @@
 	<SPLITINLINE>
 	  <SCHEME>(make-machine register-names operations controller)</SCHEME>
 	  <JAVASCRIPT>
-	    <JAVASCRIPTINLINE>make_machine(</JAVASCRIPTINLINE><LATEXINLINE>$\OptionalPar{register-names}\texttt{,}$</LATEXINLINE>
-            <LATEXINLINE>$\OptionalPar{operations}\texttt{,}$</LATEXINLINE>
-            <LATEXINLINE>$\OptionalPar{controller}$</LATEXINLINE><JAVASCRIPTINLINE>)</JAVASCRIPTINLINE>
+	    <JAVASCRIPTINLINE>make_machine(</JAVASCRIPTINLINE><LATEXINLINE>$\textit{register-names}$</LATEXINLINE><JAVASCRIPTINLINE>,</JAVASCRIPTINLINE> <LATEXINLINE>$\textit{operations}$</LATEXINLINE><JAVASCRIPTINLINE>,</JAVASCRIPTINLINE> <LATEXINLINE>$\textit{controller}$</LATEXINLINE><JAVASCRIPTINLINE>)</JAVASCRIPTINLINE>
 	  </JAVASCRIPT>
 	</SPLITINLINE>
 	<BR/>
@@ -51,9 +49,9 @@
 	<SPLITINLINE>
 	  <SCHEME>(set_register_contents machine-model register-name value)</SCHEME>
 	  <JAVASCRIPT>
-	    <JAVASCRIPTINLINE>set_register_contents(</JAVASCRIPTINLINE><LATEXINLINE>$\OptionalPar{machine-model}\texttt{,}$</LATEXINLINE>
-	    <LATEXINLINE>$\OptionalPar{register-name}\texttt{,}$</LATEXINLINE>
-            <LATEXINLINE>$\OptionalPar{value}$</LATEXINLINE><JAVASCRIPTINLINE>)</JAVASCRIPTINLINE>
+	    <JAVASCRIPTINLINE>set_register_contents(</JAVASCRIPTINLINE><LATEXINLINE>$\textit{machine-model}$</LATEXINLINE><JAVASCRIPTINLINE>,</JAVASCRIPTINLINE> 
+	    <LATEXINLINE>$\textit{register-name}$</LATEXINLINE><JAVASCRIPTINLINE>,</JAVASCRIPTINLINE> 
+            <LATEXINLINE>$\textit{value}$</LATEXINLINE><JAVASCRIPTINLINE>)</JAVASCRIPTINLINE>
 	  </JAVASCRIPT>
 	</SPLITINLINE>
 	<BR/>
@@ -64,8 +62,8 @@
 	<SPLITINLINE>
 	  <SCHEME>(get-register-contents machine-model, register-name)</SCHEME>
 	  <JAVASCRIPT>
-	    <JAVASCRIPTINLINE>get_register_contents(</JAVASCRIPTINLINE><LATEXINLINE>$\OptionalPar{machine-model}\texttt{,}$</LATEXINLINE>
-            <LATEXINLINE>$\OptionalPar{register-name}$</LATEXINLINE><JAVASCRIPTINLINE>)</JAVASCRIPTINLINE>
+	    <JAVASCRIPTINLINE>get_register_contents(</JAVASCRIPTINLINE><LATEXINLINE>$\textit{machine-model}$</LATEXINLINE><JAVASCRIPTINLINE>,</JAVASCRIPTINLINE>
+            <LATEXINLINE>$\textit{register-name}$</LATEXINLINE><JAVASCRIPTINLINE>)</JAVASCRIPTINLINE>
 	  </JAVASCRIPT>
 	</SPLITINLINE>
 	<BR/>
@@ -76,7 +74,7 @@
 	<SPLITINLINE>
 	  <SCHEME>(start machine-model)</SCHEME>
 	  <JAVASCRIPT>
-	    <JAVASCRIPTINLINE>start(</JAVASCRIPTINLINE><LATEXINLINE>$\OptionalPar{machine-model}$</LATEXINLINE><JAVASCRIPTINLINE>)</JAVASCRIPTINLINE>
+	    <JAVASCRIPTINLINE>start(</JAVASCRIPTINLINE><LATEXINLINE>$\textit{machine-model}$</LATEXINLINE><JAVASCRIPTINLINE>)</JAVASCRIPTINLINE>
 	  </JAVASCRIPT>
 	</SPLITINLINE>
 	<BR/>

--- a/xml/chapter5/section3/subsection1.xml
+++ b/xml/chapter5/section3/subsection1.xml
@@ -65,8 +65,8 @@
 	  </SCHEME>
 	  <JAVASCRIPT>
 	    <JAVASCRIPTINLINE>vector_ref(</JAVASCRIPTINLINE><!--
-	 --><LATEXINLINE>$\OptionalPar{vector}$</LATEXINLINE>,
-	    <LATEXINLINE>$\OptionalPar{n}$</LATEXINLINE><!--
+	 --><LATEXINLINE>$\textit{vector}$</LATEXINLINE>,
+	    <LATEXINLINE>$\textit{n}$</LATEXINLINE><!--
 	 --><JAVASCRIPTINLINE>)</JAVASCRIPTINLINE>
 	  </JAVASCRIPT>
 	</SPLITINLINE>
@@ -83,9 +83,9 @@
 	  </SCHEME>
 	  <JAVASCRIPT>
 	    <JAVASCRIPTINLINE>vector_set(</JAVASCRIPTINLINE><!--
-	 --><LATEXINLINE>$\OptionalPar{vector}$</LATEXINLINE>,
-	    <LATEXINLINE>$\OptionalPar{n}$</LATEXINLINE>,
-	    <LATEXINLINE>$\OptionalPar{value}$</LATEXINLINE><!--
+	 --><LATEXINLINE>$\textit{vector}$</LATEXINLINE>,
+	    <LATEXINLINE>$\textit{n}$</LATEXINLINE>,
+	    <LATEXINLINE>$\textit{value}$</LATEXINLINE><!--
 	 --><JAVASCRIPTINLINE>)</JAVASCRIPTINLINE>
 	  </JAVASCRIPT>
 	</SPLITINLINE>
@@ -474,8 +474,8 @@
 (assign ^reg<LATEXINLINE>$_{1}$</LATEXINLINE>^ (op cdr) (reg ^reg<LATEXINLINE>$_{2}$</LATEXINLINE>^))
       </SCHEME>
       <JAVASCRIPT>
-assign($\OptionalPar[1]{reg}$, list(op("head"), reg($\OptionalPar[2]{reg}$)))
-assign($\OptionalPar[1]{reg}$, list(op("tail"), reg($\OptionalPar[2]{reg}$)))
+assign($reg_1$, list(op("head"), reg($reg_2$)))
+assign($reg_1$, list(op("tail"), reg($reg_2$)))
       </JAVASCRIPT>
     </SNIPPET>
     if we implement these, respectively, as
@@ -485,8 +485,8 @@ assign($\OptionalPar[1]{reg}$, list(op("tail"), reg($\OptionalPar[2]{reg}$)))
 (assign ^reg<LATEXINLINE>$_{1}$</LATEXINLINE>^ (op vector-ref) (reg the-cdrs) (reg ^reg<LATEXINLINE>$_{2}$</LATEXINLINE>^))
       </SCHEME>
       <JAVASCRIPT>
-assign($\OptionalPar[1]{reg}$, list(op("vector_ref"), reg("the_heads"), reg($\OptionalPar[2]{reg}$)))
-assign($\OptionalPar[1]{reg}$, list(op("vector_ref"), reg("the_tails"), reg($\OptionalPar[2]{reg}$)))
+assign($reg_1$, list(op("vector_ref"), reg("the_heads"), reg($reg_2$)))
+assign($reg_1$, list(op("vector_ref"), reg("the_tails"), reg($reg_2$)))
       </JAVASCRIPT>
     </SNIPPET>
 
@@ -499,8 +499,8 @@ assign($\OptionalPar[1]{reg}$, list(op("vector_ref"), reg("the_tails"), reg($\Op
 (perform (op set-cdr!) (reg ^reg<LATEXINLINE>$_{1}$</LATEXINLINE>^) (reg ^reg<LATEXINLINE>$_{2}$</LATEXINLINE>^))
       </SCHEME>
       <JAVASCRIPT>
-perform(list(op("set_head"), reg($\OptionalPar[1]{reg}$), reg($\OptionalPar[2]{reg}$)))
-perform(list(op("set_tail"), reg($\OptionalPar[1]{reg}$), reg($\OptionalPar[2]{reg}$)))
+perform(list(op("set_head"), reg($reg_1$), reg($reg_2$)))
+perform(list(op("set_tail"), reg($reg_1$), reg($reg_2$)))
       </JAVASCRIPT>
     </SNIPPET>
     are implemented as
@@ -512,8 +512,8 @@ perform(list(op("set_tail"), reg($\OptionalPar[1]{reg}$), reg($\OptionalPar[2]{r
  (op vector-set!) (reg the-cdrs) (reg ^reg<LATEXINLINE>$_{1}$</LATEXINLINE>^) (reg ^reg<LATEXINLINE>$_{2}$</LATEXINLINE>^))
       </SCHEME>
       <JAVASCRIPT>
-perform(op("vector_set"), list(reg("the_heads"), reg($\OptionalPar[1]{reg}$), reg($\OptionalPar[2]{reg}$)))
-perform(op("vector_set"), list((reg("the_tails"), reg($\OptionalPar[1]{reg}$), reg($\OptionalPar[2]{reg}$)))
+perform(op("vector_set"), list(reg("the_heads"), reg($reg_1$), reg($reg_2$)))
+perform(op("vector_set"), list((reg("the_tails"), reg($reg_1$), reg($reg_2$)))
       </JAVASCRIPT>
     </SNIPPET>
   </TEXT>
@@ -559,7 +559,7 @@ perform(op("vector_set"), list((reg("the_tails"), reg($\OptionalPar[1]{reg}$), r
 (assign ^reg<LATEXINLINE>$_{1}$</LATEXINLINE>^ (op cons) (reg ^reg<LATEXINLINE>$_{2}$</LATEXINLINE>^) (reg ^reg<LATEXINLINE>$_{3}$</LATEXINLINE>^))
       </SCHEME>
       <JAVASCRIPT>
-assign($\OptionalPar[1]{reg}$, list(op("pair"), reg($\OptionalPar[2]{reg}$), reg($\OptionalPar[3]{reg}$)))
+assign($reg_1$, list(op("pair"), reg($reg_2$), reg($reg_3$)))
       </JAVASCRIPT>
     </SNIPPET>
     is implemented as the following sequence of vector
@@ -597,9 +597,9 @@ assign($\OptionalPar[1]{reg}$, list(op("pair"), reg($\OptionalPar[2]{reg}$), reg
       (assign free (op +) (reg free) (const 1))
       </SCHEME>
       <JAVASCRIPT>
-perform(op("vector_set"), list(reg("the_heads"), reg("free"), reg($\OptionalPar[2]{reg}$))),
-perform(op("vector_set"), list(reg("the_tails"), reg("free"), reg($\OptionalPar[3]{reg}$))),
-assign($\OptionalPar[1]{reg}$, reg("free")),
+perform(op("vector_set"), list(reg("the_heads"), reg("free"), reg($reg_2$))),
+perform(op("vector_set"), list(reg("the_tails"), reg("free"), reg($reg_3$))),
+assign($reg_1$, reg("free")),
 assign("free", list(op("+"), reg("free"), constant(1)))
       </JAVASCRIPT>
     </SNIPPET>
@@ -617,7 +617,7 @@ assign("free", list(op("+"), reg("free"), constant(1)))
 (op eq?) (reg ^reg<LATEXINLINE>$_{1}$</LATEXINLINE>^) (reg ^reg<LATEXINLINE>$_{2}$</LATEXINLINE>^)
       </SCHEME>
       <JAVASCRIPT>
-list(op("==="), reg($\OptionalPar[1]{reg}$), reg($\OptionalPar[2]{reg}$))
+list(op("==="), reg($reg_1$), reg($reg_2$))
       </JAVASCRIPT>
     </SNIPPET>
     simply tests the equality of all fields in the registers, and
@@ -662,7 +662,7 @@ list(op("==="), reg($\OptionalPar[1]{reg}$), reg($\OptionalPar[2]{reg}$))
     Thus,
     <SPLITINLINE>
       <SCHEME><SCHEMEINLINE>(save ^reg^)</SCHEMEINLINE></SCHEME>
-      <JAVASCRIPT><JAVASCRIPTINLINE>save(</JAVASCRIPTINLINE><LATEXINLINE>$\OptionalPar{reg}$</LATEXINLINE><JAVASCRIPTINLINE>)</JAVASCRIPTINLINE></JAVASCRIPT>
+      <JAVASCRIPT><JAVASCRIPTINLINE>save(</JAVASCRIPTINLINE><LATEXINLINE>$\textit{reg}$</LATEXINLINE><JAVASCRIPTINLINE>)</JAVASCRIPTINLINE></JAVASCRIPT>
     </SPLITINLINE>
     can be implemented as
     <INDEX><USE>save</USE> (in register machine)<SUBINDEX>implementing</SUBINDEX></INDEX>
@@ -671,7 +671,7 @@ list(op("==="), reg($\OptionalPar[1]{reg}$), reg($\OptionalPar[2]{reg}$))
 (assign the-stack (op cons) (reg ^reg^) (reg the-stack))
       </SCHEME>
       <JAVASCRIPT>
-assign("the_stack", list(op("pair"), reg($\OptionalPar{reg}$), reg("the_stack")))
+assign("the_stack", list(op("pair"), reg($reg$), reg("the_stack")))
       </JAVASCRIPT>
     </SNIPPET>
     <INDEX><USE>restore</USE> (in register machine)<SUBINDEX>implementing</SUBINDEX></INDEX>
@@ -680,7 +680,7 @@ assign("the_stack", list(op("pair"), reg($\OptionalPar{reg}$), reg("the_stack"))
       <SCHEME><SCHEMEINLINE>(restore ^reg^)</SCHEMEINLINE></SCHEME>
       <JAVASCRIPT>
 	<JAVASCRIPTINLINE>restore(</JAVASCRIPTINLINE>
-	<LATEXINLINE>$\OptionalPar{reg}$</LATEXINLINE>
+	<LATEXINLINE>$\textit{reg}$</LATEXINLINE>
       <JAVASCRIPTINLINE>)</JAVASCRIPTINLINE></JAVASCRIPT>
     </SPLITINLINE>
     can be implemented as
@@ -690,7 +690,7 @@ assign("the_stack", list(op("pair"), reg($\OptionalPar{reg}$), reg("the_stack"))
 (assign the-stack (op cdr) (reg the-stack))
       </SCHEME>
       <JAVASCRIPT>
-assign($\OptionalPar{reg}$, list(op("head"), reg("the_stack")))
+assign($reg$, list(op("head"), reg("the_stack")))
 assign("the_stack", list(op("tail"), reg("the_stack")))
       </JAVASCRIPT>
     </SNIPPET>

--- a/xml/chapter5/section5/subsection3.xml
+++ b/xml/chapter5/section5/subsection3.xml
@@ -549,11 +549,11 @@ $$  test(op("primitive_function"), reg("fun")),
 "compiled_branch",
   $\langle\text{\it code to apply compiled function with given target and appropriate linkage} \rangle$
 "primitive_branch",
-  assign($\OptionalPar{target}$,
+  assign($target$,
          list(op("apply_primitive_function"),
          reg("fun"),
          reg("argl")))
-$\OptionalPar{linkage}$
+$linkage$
 "after_call"
       </JAVASCRIPT>
     </SNIPPET>
@@ -739,8 +739,8 @@ $$  assign("continue", label("fun_return")),
   assign("val", list(op("compiled_function_entry"), reg("fun"))),
   go_to(reg("val")),
 "fun_return",
-  assign($\OptionalPar{target}$, reg("val")),   // included if target is not val
-  go_to(label($\OptionalPar{linkage}$)),        // linkage code
+  assign($target$, reg("val")),   // included if target is not val
+  go_to(label($linkage$)),        // linkage code
       </JAVASCRIPT>
     </SNIPPET>
 
@@ -773,7 +773,7 @@ $$  assign("continue", label("fun_return")),
   assign("val", list(op("compiled_function_entry"), reg("fun"))),
   go_to(reg("val")),
 "fun_return",
-  assign($\OptionalPar{target}$, reg("val")),   // included if target is not val
+  assign($target$, reg("val")),   // included if target is not val
   restore("continue"),
   go_to(reg("continue")),         // linkage code
       </JAVASCRIPT>
@@ -792,7 +792,7 @@ $$  assign("continue", label("return_undefined")),
   assign("val", list(op("compiled_function_entry"), reg("fun"))),
   go_to(reg("val")),
 "return_undefined",
-  assign($\OptionalPar{target}$, constant(undefined)),   // included even if target is val
+  assign($target$, constant(undefined)),   // included even if target is val
   restore_marker(),
   restore("continue"),
   go_to(reg("continue")),         // linkage code
@@ -988,7 +988,7 @@ go_to(reg("val")),
       <SCHEME><SCHEMEINLINE>(goto (label ^linkage^))</SCHEMEINLINE></SCHEME>
       <JAVASCRIPT>
 	<JAVASCRIPTINLINE>go_to(label(</JAVASCRIPTINLINE>
-	<LATEXINLINE>$\OptionalPar{linkage}$</LATEXINLINE>
+	<LATEXINLINE>$\textit{linkage}$</LATEXINLINE>
 	<JAVASCRIPTINLINE>))</JAVASCRIPTINLINE>
       </JAVASCRIPT>
     </SPLITINLINE>
@@ -1007,7 +1007,7 @@ go_to(reg("val")),
       (goto (reg val))
       </SCHEME>
       <JAVASCRIPT>
-assign("continue", label($\OptionalPar{linkage}$)),
+assign("continue", label($linkage$)),
 save("continue"),
 save_marker(),
 assign("val", list(op("compiled_function_entry"), reg("fun"))),


### PR DESCRIPTION
The problem: \OptionalPar uses \ensuremath and MathJax does not support \ensuremath.

Elsewhere in the book, I'm using 
<LATEXINLINE>$\textit{bla-bla-bla}$</LATEXINLINE>
in the text and within SNIPPET LATEX=yes
i'm just using
       ...$bla$-$bla$-$bla$...
