### PR TITLE
meta variables in snippets and inline, including hyphens

### DIFF
--- a/javascript/latexContent.js
+++ b/javascript/latexContent.js
@@ -148,6 +148,7 @@ export const preamble = `\\documentclass[a4paper, 12pt]{book}
 }
 
 \\newcommand{\\OptionalPar}[2][]{\\ensuremath{\\text{\\textrm{\\sl #2}}_{#1}}}
+\\mathchardef\\mhyphen="2D 
 
 \\usepackage[svgnames]{xcolor}
 \\definecolor{LeftBarClickable}{RGB}{187, 187, 187}

--- a/javascript/latexContent.js
+++ b/javascript/latexContent.js
@@ -148,6 +148,7 @@ export const preamble = `\\documentclass[a4paper, 12pt]{book}
 }
 
 \\newcommand{\\OptionalPar}[2][]{\\ensuremath{\\text{\\textrm{\\sl #2}}_{#1}}}
+% \mhyphen{} in math mode creates hyphen character (META in parseXmlLatex.js)
 \\mathchardef\\mhyphen="2D 
 
 \\usepackage[svgnames]{xcolor}

--- a/javascript/parseXmlHtml.js
+++ b/javascript/parseXmlHtml.js
@@ -231,6 +231,14 @@ const processTextFunctionsDefaultHtml = {
     processTextHtml(node, writeTo);
   },
 
+  META: (node, writeTo) => {
+    writeTo.push("$");
+    let s = node.firstChild.nodeValue;
+    s = s.replace(/-/g, "$-$");
+    writeTo.push(s);
+    writeTo.push("$");
+  },
+
   IMAGE: (node, writeTo) => {
     writeTo.push(`<IMAGE src="${toIndexFolder}${node.getAttribute("src")}"/>`);
   },
@@ -347,7 +355,7 @@ const processTextFunctionsDefaultHtml = {
       writeTo.push("<kbd class='snippet'>");
       const textit = getChildrenByTagName(node, "JAVASCRIPT")[0];
       if (textit) {
-        recursiveProcessPureText(textit.firstChild, writeTo, {
+        recursiveProcessTextHtml(textit.firstChild, writeTo, {
           removeNewline: "beginning&end"
         });
       } else {

--- a/javascript/parseXmlLatex.js
+++ b/javascript/parseXmlLatex.js
@@ -63,11 +63,16 @@ const processTextFunctionsDefaultLatex = {
   },
 
   "#text": (node, writeTo) => {
-    const trimedValue = node.nodeValue
-      .replace(/[\r\n]+/, " ")
-      .replace(/\s+/g, " ")
-      .replace(/\^/g, "^{}")
-      .replace(/%/g, "\\%");
+    let trimedValue;
+    if (ancestorHasTag(node, "SNIPPET")) {
+      trimedValue = node.nodeValue.replace(/\^/g, "^{}").replace(/%/g, "\\%");
+    } else {
+      trimedValue = node.nodeValue
+        .replace(/[\r\n]+/, " ")
+        .replace(/\s+/g, " ")
+        .replace(/\^/g, "^{}")
+        .replace(/%/g, "\\%");
+    }
     if (trimedValue.match(/&(\w|\.)+;/)) {
       processFileInput(trimedValue.trim(), writeTo);
     } else {
@@ -157,6 +162,14 @@ const processTextFunctionsDefaultLatex = {
     writeTo.push("\\subsection*{");
     recursiveProcessTextLatex(node.firstChild, writeTo);
     writeTo.push("}");
+  },
+
+  META: (node, writeTo) => {
+    writeTo.push("$\\mathit{");
+    let s = node.firstChild.nodeValue;
+    s = s.replace(/-/g, "\\mhyphen ");
+    writeTo.push(s);
+    writeTo.push("}$");
   },
 
   INDEX: (node, writeTo) => {

--- a/javascript/parseXmlLatex.js
+++ b/javascript/parseXmlLatex.js
@@ -167,7 +167,7 @@ const processTextFunctionsDefaultLatex = {
   META: (node, writeTo) => {
     writeTo.push("$\\mathit{");
     let s = node.firstChild.nodeValue;
-    s = s.replace(/-/g, "\\mhyphen ");
+    s = s.replace(/-/g, "\\mhyphen{}");
     writeTo.push(s);
     writeTo.push("}$");
   },

--- a/javascript/parseXmlLatex.js
+++ b/javascript/parseXmlLatex.js
@@ -65,7 +65,7 @@ const processTextFunctionsDefaultLatex = {
   "#text": (node, writeTo) => {
     let trimedValue;
     if (ancestorHasTag(node, "SNIPPET")) {
-      trimedValue = node.nodeValue.replace(/\^/g, "^{}").replace(/%/g, "\\%");
+      trimedValue = node.nodeValue;
     } else {
       trimedValue = node.nodeValue
         .replace(/[\r\n]+/, " ")

--- a/javascript/processingFunctions/processSnippetPdf.js
+++ b/javascript/processingFunctions/processSnippetPdf.js
@@ -115,7 +115,7 @@ export const processSnippetPdf = (node, writeTo) => {
     }
 
     const codeArr = [];
-    recursiveProcessPureText(jsSnippet.firstChild, codeArr);
+    recursiveProcessTextLatex(jsSnippet.firstChild, codeArr);
     const codeStr = codeArr.join("").trim();
 
     const codeArr_run = [];

--- a/xml/chapter1/section3/subsection2.xml
+++ b/xml/chapter1/section3/subsection2.xml
@@ -927,7 +927,7 @@ function expmod(base, exp, m) {
       The general form of a conditional statement is
       <SNIPPET EVAL="no" LATEX="yes">
 	<JAVASCRIPT>
-if ($predicate$) { $consequent$-$statements$ } else { $alternative$-$statements$ }
+if (<META>predicate</META>) { <META>consequent-statements</META> } else { <META>alternative-statements</META> }
 	</JAVASCRIPT>
       </SNIPPET>
       <INDEX>alternative<SUBINDEX><ORDER>conditional statement</ORDER>of conditional statement</SUBINDEX></INDEX>
@@ -935,11 +935,11 @@ if ($predicate$) { $consequent$-$statements$ } else { $alternative$-$statements$
       <INDEX>conditional statement<SUBINDEX>consequent statements of</SUBINDEX></INDEX>
       <INDEX>conditional statement<SUBINDEX>alternative statements of</SUBINDEX></INDEX>
       and, as for a conditional expression, the interpreter first evaluates the
-      <LATEXINLINE>$\textit{predicate}$</LATEXINLINE>. If it evaluates to true,
+      <META>predicate</META>. If it evaluates to true,
       the interpreter evaluates the
-      <LATEXINLINE>$\textit{consequent-statements}$</LATEXINLINE>, and if it
+      <META>consequent-statements</META>, and if it
       evaluates to false, the interpreter evaluates
-      the <LATEXINLINE>$\textit{alternative-statements}$</LATEXINLINE>. Note that
+      the <META>alternative-statements</META>. Note that
       any constant declarations occurring in either part are local to that part,
       because each part is enclosed in braces and thus forms its own block.
       As in function bodies, the statements in the

--- a/xml/chapter4/section1/subsection2.xml
+++ b/xml/chapter4/section1/subsection2.xml
@@ -423,17 +423,32 @@ list("sequence",
 	Literal expressions are parsed into tagged lists with
 	tag <JAVASCRIPTINLINE>"literal"</JAVASCRIPTINLINE> and
 	the actual value.
-	<LATEX>
-	  \begin{eqnarray*}
-	  \ll \textit{literal-expression} \gg &amp; = &amp;
-	  \texttt{list("literal", }\textit{value}\texttt{)}
-	  \end{eqnarray*}
-	</LATEX>
-	where <LATEXINLINE>$\textit{value}$</LATEXINLINE> is
-	the JavaScript value represented by the
-	<LATEXINLINE>$\textit{literal-expression}$</LATEXINLINE> string.
-	Here <LATEXINLINE>$\ll\textit{literal-expression}\gg$</LATEXINLINE> denotes the
-	result of parsing the string <LATEXINLINE>$\textit{literal-expression}$</LATEXINLINE>.
+	<WEB_ONLY>
+	  <LATEX>
+	    \begin{eqnarray*}
+	    \ll \textit{literal-expression} \gg &amp; = &amp;
+	    \texttt{list("literal", }\textit{value}\texttt{)}
+	    \end{eqnarray*}
+	  </LATEX>
+	  where <LATEXINLINE>$\textit{value}$</LATEXINLINE> is
+	  the JavaScript value represented by the
+	  <LATEXINLINE>$\textit{literal-expression}$</LATEXINLINE> string.
+	  Here <LATEXINLINE>$\ll\textit{literal-expression}\gg$</LATEXINLINE> denotes the
+	  result of parsing the string <LATEXINLINE>$\textit{literal-expression}$</LATEXINLINE>.
+	</WEB_ONLY>
+	<PDF_ONLY>
+	  <LATEX>
+	    \begin{eqnarray*}
+	    \ll \mathit{literal}\mhyphen\mathit{expression} \gg &amp; = &amp;
+	    \texttt{list("literal", }\mathit{value}\texttt{)}
+	    \end{eqnarray*}
+	  </LATEX>
+	  where <META>value</META> is
+	  the JavaScript value represented by the
+	  <META>literal-expression</META> string.
+	  Here <LATEXINLINE>$\ll\mathit{literal}\mhyphen\mathit{expression}\gg$</LATEXINLINE> denotes the
+	  result of parsing the string <META>literal-expression</META>.
+	</PDF_ONLY>
 	<SNIPPET>
 	  <NAME>parse_literal_example</NAME>
 	  <JAVASCRIPT>


### PR DESCRIPTION
Attempting to fix the issue of meta variables in snippets and inline.
Allowing META tags in both places. 

In PDF_ONLY, \mhyphen produces a hyphen in math mode, which comes in handy in 4.1.2. This is not supported outside of PDF_ONLY. In WEB_ONLY, use single hyphen instead. See 4.1.2 literals for an example.