### PR TITLE
Fix buggy TOC sort algorithm and prefaces being overwritten

### DIFF
--- a/javascript/generateTocHtml.js
+++ b/javascript/generateTocHtml.js
@@ -19,7 +19,7 @@ const generateChapterIndex = filename => {
   if (filename.match(/foreword/)) {
     chapterIndex = "foreword";
   } else if (filename.match(/prefaces/)) {
-    chapterIndex = "prefaces";
+    chapterIndex = filename.match(/prefaces\d*/g)[0];
   } else if (filename.match(/acknowledgements/)) {
     chapterIndex = "acknowledgements";
   } else if (filename.match(/references/)) {
@@ -68,34 +68,22 @@ export const generateTOC = (doc, tableOfContent, filename) => {
 
 export const sortTOC = allFilepath => {
   allFilepath = allFilepath.sort();
-  let sortedFilepath = [];
-  const totalFileCount = allFilepath.length;
 
-  for (var i = 0; i < totalFileCount; i++) {
-    const filename = allFilepath[i];
+  let head = [];
+  let mid = [];
+  let tail = [];
 
-    if (filename.match(/foreword/)) {
-      sortedFilepath[0] = filename;
-    } else if (filename.match(/prefaces96/)) {
-      sortedFilepath[3] = filename;
-    } else if (filename.match(/prefaces84/)) {
-      sortedFilepath[2] = filename;
-    } else if (filename.match(/prefaces/)) {
-      sortedFilepath[1] = filename;
-    } else if (filename.match(/acknowledgements/)) {
-      sortedFilepath[4] = filename;
-    } else if (filename.match(/see/)) {
-      sortedFilepath[5] = filename;
-    } else if (filename.match(/references/)) {
-      sortedFilepath[totalFileCount - 2] = filename;
-    } else if (filename.match(/making/)) {
-      sortedFilepath[totalFileCount - 1] = filename;
+  for (const filename of allFilepath) {
+    if (filename.match(/foreword/) || filename.match(/prefaces/) || filename.match(/acknowledgements/) || filename.match(/see/)) {
+      head.push(filename);
+    } else if (filename.match(/references/) || filename.match(/making/)) {
+      tail.push(filename);
     } else {
-      sortedFilepath[i + 6] = filename;
+      mid.push(filename);
     }
   }
 
-  return sortedFilepath;
+  return head.concat(mid, tail);
 };
 
 export const recursiveProcessTOC = (index, writeTo, option, toIndexFolder) => {
@@ -114,7 +102,7 @@ export const recursiveProcessTOC = (index, writeTo, option, toIndexFolder) => {
   const nextOption = option;
 
   if (index == 0 && option == "sidebar") {
-    writeTo.push(`       
+    writeTo.push(`
         <div class="collapse" id="nav-sidebar" role="tablist" aria-multiselectable="true">
         <!-- insert a dummy entry, to give one extra line of space -->
         <a class="navbar-brand" href="index.html">&nbsp;</a>
@@ -214,7 +202,7 @@ export const recursiveProcessTOC = (index, writeTo, option, toIndexFolder) => {
                   <a href="${toIndexFolder}${chapterIndex}.html">${displayTitle}</a>
                 </h5>
               </div>
-    
+
               <div id="sidebar-collapse-${
                 index + 1
               }" class="collapse" role="tabpanel" aria-labelledby="headingOne">


### PR DESCRIPTION
1. The multiple preface chapters are being written to the same `prefaces.html`, so only the last one is actually there. Fix that.

2. The TOC sort algorithm is a bit hacky. Fix that too.

---

Unrelated issue: these

```xml
  <SECTION>
    <NAME>Preface to the JavaScript Adaptation</NAME>
  </SECTION>
```

in `03prefaces03.xml` seem like they should be `SUBHEADING`s instead.