### PR TITLE
Fixing non-sequitur in 5.5 by going back to SICP

### DIFF
--- a/xml/chapter5/section5/section5.xml
+++ b/xml/chapter5/section5/section5.xml
@@ -172,71 +172,47 @@
     Compared with interpretation, compilation can provide a great increase
     in the efficiency of program execution, as we will explain below in
     the overview of the compiler.
-    <SPLIT>
-      <SCHEME>
-	On the other hand, an interpreter
-	provides a more powerful environment for interactive program
-	development and debugging, because the source program being executed
-	is available at run time to be examined and modified.  In addition,
-	because the entire library of primitives is present, new programs can
-	be constructed and added to the system during debugging.
-      </SCHEME>
-      <JAVASCRIPT>
-	On the other
-	hand, an interpreter can immediately evaluate programs without
-	the need for compilation and thereby increase the
-	responsiveness of an application.
-      </JAVASCRIPT>
-    </SPLIT>
+    On the other hand, an interpreter
+    provides a more powerful environment for interactive program
+    development and debugging, because the source program being executed
+    is available at run time to be examined and modified.  In addition,
+    because the entire library of primitives is present, new programs can
+    be constructed and added to the system during debugging.
   </TEXT>
 
   <TEXT>
-	In view of the complementary advantages of compilation and
-	interpretation, modern
-	<SPLITINLINE>
-	  <SCHEME>
-	    program-development environments
-	  </SCHEME>
-	  <JAVASCRIPT>
-	    language processors
-	  </JAVASCRIPT>
-	</SPLITINLINE>
-	pursue a mixed
-	strategy.
-	<SPLITINLINE>
-	  <SCHEME>Lisp interpreters</SCHEME>
-	  <JAVASCRIPT>JavaScript systems</JAVASCRIPT>
-	</SPLITINLINE>
-	are generally organized so that interpreted
-	<SPLITINLINE>
-	  <SCHEME>procedures</SCHEME>
-	  <JAVASCRIPT>functions</JAVASCRIPT>
-	</SPLITINLINE>
-	and compiled
-	<SPLITINLINE>
-	  <SCHEME>procedures</SCHEME>
-	  <JAVASCRIPT>functions</JAVASCRIPT>
-	</SPLITINLINE>
-	can call each other.
-    <SPLIT>
-      <SCHEME>
-	This enables a programmer to compile those parts of a
-	program that are assumed to be debugged, thus gaining the efficiency
-	advantage of compilation, while retaining the interpretive mode of execution
-	for those parts of the program that are in the flux of interactive
-	development and debugging.
-      </SCHEME>
-      <JAVASCRIPT>
-	Programs are interpreted, but the interpreter monitors how often
-	interpreted functions are being called, and compiles functions
-	<QUOTE>just in time</QUOTE> when an overall performance
-	advantage for doing so can be expected. The system thereby
-	gains the efficiency advantage of compilation
-	while retaining the interpretive mode of execution for those
-	parts of the program for which compilation would require more time
-	than is saved.
-      </JAVASCRIPT>
-    </SPLIT>
+    In view of the complementary advantages of compilation and
+    interpretation, modern
+    program-development environments
+    pursue a mixed
+    strategy.
+    <SPLITINLINE>
+      <SCHEME>Lisp interpreters</SCHEME>
+      <JAVASCRIPT>JavaScript systems</JAVASCRIPT>
+    </SPLITINLINE>
+    are generally organized so that interpreted
+    <SPLITINLINE>
+      <SCHEME>procedures</SCHEME>
+      <JAVASCRIPT>functions</JAVASCRIPT>
+    </SPLITINLINE>
+    and compiled
+    <SPLITINLINE>
+      <SCHEME>procedures</SCHEME>
+      <JAVASCRIPT>functions</JAVASCRIPT>
+    </SPLITINLINE>
+    can call each other.
+    This enables a programmer to compile those parts of a
+    program that are assumed to be debugged, thus gaining the efficiency
+    advantage of compilation, while retaining the interpretive mode of execution
+    for those parts of the program that are in the flux of interactive
+    development and
+    debugging.<SPLITINLINE><JAVASCRIPT><FOOTNOTE>Language implementations
+    often delay the compilation of program parts even when they are
+    assumed to be debugged, until there is enough evidence that compiling them
+    would lead to an overall efficiency advantage. The evidence is obtained at
+    runtime by monitoring the number of times the program parts are being
+    interpreted. This technique is called
+    <EM>just-in-time compilation</EM>.</FOOTNOTE></JAVASCRIPT></SPLITINLINE>
     <INDEX>compiler<SUBINDEX>interpreter vs.<CLOSE/></SUBINDEX></INDEX>
     <INDEX>interpreter<SUBINDEX>compiler vs.<CLOSE/></SUBINDEX></INDEX>
     <INDEX>compiler<CLOSE/></INDEX>
@@ -248,13 +224,6 @@
       <SCHEME>development</SCHEME>
     </SPLITINLINE>
     system.
-    <SPLIT>
-      <JAVASCRIPT>
-	For the sake of simplicity, our system
-	lets the programmer decide which functions should be compiled
-	and which ones should be interpreted.
-      </JAVASCRIPT>
-    </SPLIT>
   </TEXT>
 
   <SUBHEADING>

--- a/xml/chapter5/section5/section5.xml
+++ b/xml/chapter5/section5/section5.xml
@@ -188,7 +188,7 @@
     strategy.
     <SPLITINLINE>
       <SCHEME>Lisp interpreters</SCHEME>
-      <JAVASCRIPT>JavaScript systems</JAVASCRIPT>
+      <JAVASCRIPT>These systems</JAVASCRIPT>
     </SPLITINLINE>
     are generally organized so that interpreted
     <SPLITINLINE>

--- a/xml/chapter5/section5/subsection7.xml
+++ b/xml/chapter5/section5/subsection7.xml
@@ -1072,20 +1072,10 @@ EC-evaluate value:
     </SPLITINLINE>
     language (or any programming language) as a
     coherent family of abstractions erected on the machine language.
-    <SPLITINLINE>
-      <SCHEME>
-	Interpreters are good for interactive program development and
-	debugging because the steps of program execution are organized in
-	terms of these abstractions, and are therefore more intelligible
-	to the programmer.
-      </SCHEME>
-      <JAVASCRIPT>
-	Interpreters can directly employ these abstractions without the need
-	for compilation, and therefore an interpreter-based system can be more
-	responsive when components need to be evaluated as a result of events such
-	as pressing a button.
-      </JAVASCRIPT>
-    </SPLITINLINE>
+    Interpreters are good for interactive program development and
+    debugging because the steps of program execution are organized in
+    terms of these abstractions, and are therefore more intelligible
+    to the programmer.
     Compiled code can execute faster, because the steps of program execution
     are organized in terms of the machine language, and the compiler is free
     to make optimizations that cut across the higher-level


### PR DESCRIPTION
See email discussion with Julie (Martin's email of 18/4, subject: Re: compiler vs. interpreter