### PR TITLE
restricting use of META and JAVASCRIPTINLINE

### DIFF
--- a/javascript/latexContent.js
+++ b/javascript/latexContent.js
@@ -137,8 +137,7 @@ export const preamble = `\\documentclass[a4paper, 12pt, fleqn]{book}
 }
 
 \\lstdefinelanguage{JavaScript}{
-  keywords={function,if,else,return,const,let,break,for,while,true,false,var,null}, %% removing continue for now
-  %% keywords={const, let, break, case, catch, continue, debugger, default, delete, do, else, finally, for, function, if, in, instanceof, return, switch, this, throw, try, typeof, var, void, while, with},
+  keywords={const, let, break, case, catch, const, continue, debugger, default, delete, do, else, false, finally, for, function, if, in, instanceof, let, null, return, switch, this, throw, true, try, typeof, var, void, while, with},
   morecomment=[l]{//},
   morecomment=[s]{/*}{*/},
   morestring=[b]',

--- a/javascript/parseXmlLatex.js
+++ b/javascript/parseXmlLatex.js
@@ -68,9 +68,7 @@ const processTextFunctionsDefaultLatex = {
       trimedValue = node.nodeValue;
     } else {
       trimedValue = node.nodeValue;
-      if (ancestorHasTag(node, "JAVASCRIPTINLINE")) {
-        trimedValue = trimedValue.replace(/\{/g, "\\{").replace(/\}/g, "\\}");
-      } else {
+      if (!ancestorHasTag(node, "JAVASCRIPTINLINE")) {
         trimedValue = trimedValue.replace(/%/g, "\\%");
       }
       trimedValue = trimedValue

--- a/xml/chapter2/section2/subsection4.xml
+++ b/xml/chapter2/section2/subsection4.xml
@@ -705,8 +705,7 @@ show(up_split(heart, 4));
     expression can be a block, not just a single return expression.
     <INDEX>sequence of statements<SUBINDEX><ORDER>lambda</ORDER>as body of lambda expression</SUBINDEX></INDEX>
     Such lambda expressions have the following shape:
-    <PDF_ONLY><JAVASCRIPTINLINE>(</JAVASCRIPTINLINE><META>parameters</META><JAVASCRIPTINLINE>) => </JAVASCRIPTINLINE><TT>\{ </TT><META>statements</META><TT> \}</TT></PDF_ONLY>
-    <WEB_ONLY><JAVASCRIPTINLINE>(<META>parameters</META>) => { <META>statements</META> }</JAVASCRIPTINLINE></WEB_ONLY>
+    <JAVASCRIPTINLINE>(</JAVASCRIPTINLINE><META>parameters</META><JAVASCRIPTINLINE>) => { </JAVASCRIPTINLINE><META>statements</META><JAVASCRIPTINLINE> }</JAVASCRIPTINLINE>
     <LABEL NAME="foot:lambda_with_block"/>
     </FOOTNOTE></JAVASCRIPT></SPLITINLINE>
     <SPLITINLINE>

--- a/xml/chapter4/section1/subsection3.xml
+++ b/xml/chapter4/section1/subsection3.xml
@@ -406,7 +406,7 @@ return_value_content(my_return_value);
       <JAVASCRIPT>
 	<UL>
 	  <LI>
-	    <JAVASCRIPTINLINE>lookup_symbol_value(<META>symbol</META>, <META>env</META>)</JAVASCRIPTINLINE>
+	    <JAVASCRIPTINLINE>lookup_symbol_value(</JAVASCRIPTINLINE><META>symbol</META><JAVASCRIPTINLINE>, </JAVASCRIPTINLINE><META>env</META><JAVASCRIPTINLINE>)</JAVASCRIPTINLINE>
 	    <INDEX><USE>lookup_symbol_value</USE></INDEX> 
 	  <BREAK/>
 	  returns the value that is bound to
@@ -415,7 +415,7 @@ return_value_content(my_return_value);
 	  <META>symbol</META> is unbound.
 	  </LI>
 	  <LI>
-	    <JAVASCRIPTINLINE>extend_environment(<META>symbols</META>, <META>values</META>, <META>base-env</META>)</JAVASCRIPTINLINE>
+	    <JAVASCRIPTINLINE>extend_environment(</JAVASCRIPTINLINE><META>symbols</META><JAVASCRIPTINLINE>, </JAVASCRIPTINLINE><META>values</META><JAVASCRIPTINLINE>, </JAVASCRIPTINLINE><META>base-env</META><JAVASCRIPTINLINE>)</JAVASCRIPTINLINE>
 	    <INDEX><USE>extend_environment</USE></INDEX> 
 	    <BREAK/>
 	    returns a new environment, consisting of a new frame in which the
@@ -426,7 +426,7 @@ return_value_content(my_return_value);
 	    <META>base-env</META>.
 	  </LI>
 	  <LI>
-	    <JAVASCRIPTINLINE>assign_symbol_value(<META>symbol</META>, <META>value</META>, <META>env</META>)</JAVASCRIPTINLINE>
+	    <JAVASCRIPTINLINE>assign_symbol_value(</JAVASCRIPTINLINE><META>symbol</META><JAVASCRIPTINLINE>, </JAVASCRIPTINLINE><META>value</META><JAVASCRIPTINLINE>, </JAVASCRIPTINLINE><META>env</META><JAVASCRIPTINLINE>)</JAVASCRIPTINLINE>
 	    <INDEX><USE>assign_symbol_value</USE></INDEX> 
 	    <BREAK/>
 	    finds the innermost frame of
@@ -1060,6 +1060,8 @@ const unassigned_string = "*unassigned*";
 	  <LI>
 	    Before ECMAScript 2015, the only way to declare a local variable in
 	    JavaScript was using the keyword
+	    <INDEX><USE>var</USE> (keyword)</INDEX>
+	    <INDEX>keywords<SUBINDEX><ORDER>var</ORDER><USE>var</USE></SUBINDEX></INDEX>
 	    <JAVASCRIPTINLINE>var</JAVASCRIPTINLINE>
 	    instead of the keyword <JAVASCRIPTINLINE>let</JAVASCRIPTINLINE>.
 	    The scope of variables declared with

--- a/xml/chapter5/section5/subsection2.xml
+++ b/xml/chapter5/section5/subsection2.xml
@@ -1244,7 +1244,7 @@ function append_return_undefined(body) {
     Hint: the answer depends on how we define dead code. One possible (and useful)
     definition is <QUOTE>code following a return statement in a sequence</QUOTE><EMDASH/>but
     what about code in the consequent
-    branch of <JAVASCRIPTINLINE>if (false) <META>\ldots</META></JAVASCRIPTINLINE> or
+    branch of <JAVASCRIPTINLINE>if (false) </JAVASCRIPTINLINE><LATEX>$\ldots$</LATEX> or
     code following a
     call to <JAVASCRIPTINLINE>run_forever()</JAVASCRIPTINLINE> in exercise<SPACE/><REF NAME="ex:halting-theorem"/>?
   </EXERCISE>
@@ -1262,11 +1262,11 @@ function append_return_undefined(body) {
         <JAVASCRIPTINLINE>return undefined;</JAVASCRIPTINLINE> at the end of only
 	those paths that do not contain a return statement. Test your
         solution on the functions below, substituting any expressions for
-        <JAVASCRIPTINLINE><META>e_1</META></JAVASCRIPTINLINE> and
-        <JAVASCRIPTINLINE><META>e_2</META></JAVASCRIPTINLINE>
+        <LATEX>$e_1$</LATEX> and
+        <LATEX>$e_2$</LATEX>
         and any (non-return) statements for
-        <JAVASCRIPTINLINE><META>s_1</META></JAVASCRIPTINLINE> and
-	<JAVASCRIPTINLINE><META>s_2</META></JAVASCRIPTINLINE>.
+        <LATEX>$s_1$</LATEX> and
+	<LATEX>$s_2$</LATEX>.
         In <JAVASCRIPTINLINE>t1</JAVASCRIPTINLINE>, a return statement should be
 	added either at both <JAVASCRIPTINLINE>(*)</JAVASCRIPTINLINE>'s or just at
 	<JAVASCRIPTINLINE>(**)</JAVASCRIPTINLINE>.
@@ -1278,13 +1278,13 @@ function append_return_undefined(body) {
 	  <JAVASCRIPT>
 function t1(b) {    function t2(b) {    function t3(b) {    function t4(b1, b2) {
     if (b) {            if (b) {            if (b) {            if (b1) {
-        <META>s_1~~</META>                 return <META>e_1;~</META>          return <META>e_1;~</META>          return <META>e_1;</META>
+        $s_1~~$                 return $e_1$;$~$          return $e_1$;$~$          return $e_1$;
         (*)                                                     } else {
     } else {            } else {            } else {                if (b2) {
-        <META>s_2~~</META>                 <META>s_1~~</META>                 return <META>e_2;~</META>              <META>s_1</META>
+        $s_2~~$                 $s_1~~$                 return $e_2$;$~$              $s_1$
         (*)                 (*)                                         (*)
     }                   }                   }                       } else {
-    (**)                (*)                                             return <META>e_2;</META>
+    (**)                (*)                                             return $e_2$;
 }                   }                   }                           }
                                                                     (*)
                                                                 }

--- a/xml/chapter5/section5/subsection6.xml
+++ b/xml/chapter5/section5/subsection6.xml
@@ -851,8 +851,8 @@ find_symbol("w", list(list("y", "z"),
 	that can help us optimize the code.
         <OL>
           <LI>
-            A constant declaration such as <JAVASCRIPTINLINE>const
-            <META>name</META> = <META>literal</META>;</JAVASCRIPTINLINE> allows us
+            A constant declaration such as
+	    <JAVASCRIPTINLINE>const </JAVASCRIPTINLINE><META>name</META><JAVASCRIPTINLINE> = </JAVASCRIPTINLINE><META>literal</META><JAVASCRIPTINLINE>;</JAVASCRIPTINLINE> allows us
             to replace all occurrences of <META>name</META> within the scope of
             the declaration by <META>literal</META> so that <META>name</META> 
             doesn<APOS/>t have to be looked up in the runtime environment. This optimization is


### PR DESCRIPTION
See newest wiki:
* META: within <SNIPPET><JAVASCRIPT>...</JAVASCRIPT></SNIPPET> and in normal text, this will produce an italics font intended for meta variables. <META> elements must not enclose any other elements. No math allowed in <META>.
* METAPHRASE: within <SNIPPET><JAVASCRIPT>...</JAVASCRIPT></SNIPPET> and in normal text, this will produce an italics font within angle brackets, intended for meta-level phrases. <METAPHRASE> elements may include <JAVASCRIPTINLINE> elements, but no other elements. No math allowed in <METAPHRASE>.
* JAVASCRIPTINLINE: will render the enclosed string as program syntax. `<JAVASCRIPTINLINE>` elements must not enclose any other elements. The element may enclose the characters `{`, `}`, `%`, and `$`, all rendered literally.
* SCHEMEINLINE: same as JAVASCRIPTINLINE

This is to simplify the implementation of the web edition.

Fixes #458 by removing any occurrences where the issue may arise.

Fixes #459.