### PR TITLE
Remove unused imports and parameters

### DIFF
--- a/javascript/findBadTags.js
+++ b/javascript/findBadTags.js
@@ -1,9 +1,7 @@
 import fs from "fs";
-import fse from "fs-extra";
 import util from "util";
 import path from "path";
 
-import xpath from "xpath";
 import { DOMParser as dom } from "xmldom";
 
 const readdir = util.promisify(fs.readdir);

--- a/javascript/htmlContent.js
+++ b/javascript/htmlContent.js
@@ -1,7 +1,3 @@
-import { adapters, adapters_with, authors, authors_with } from "constants";
-
-import { write } from "fs-extra";
-
 const shortTitleDefault = `SICP &mdash; JS`;
 const longTitleDefault = `Structure and Interpretation of Computer Programs &mdash; JavaScript Adaptation`;
 let shortTitle = shortTitleDefault;

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -3,7 +3,6 @@ import fse from "fs-extra";
 import util from "util";
 import path from "path";
 
-import xpath from "xpath";
 import { DOMParser as dom } from "xmldom";
 
 const readdir = util.promisify(fs.readdir);
@@ -26,10 +25,7 @@ $postscript_mode = 0;`;
 import { switchTitle } from "./htmlContent";
 import { switchParseFunctionsHtml, parseXmlHtml } from "./parseXmlHtml";
 import { setupSnippetsHtml } from "./processingFunctions/processSnippetHtml";
-import {
-  setupReferences,
-  referenceStore
-} from "./processingFunctions/processReferenceHtml";
+import { setupReferences } from "./processingFunctions/processReferenceHtml";
 import { generateTOC, sortTOC, indexHtml } from "./generateTocHtml";
 export let allFilepath = [];
 export let tableOfContent = {};

--- a/javascript/latexContent.js
+++ b/javascript/latexContent.js
@@ -1,5 +1,3 @@
-import { adapters, adapters_with, authors, authors_with } from "constants";
-
 const title = `\\begin{titlepage}
   \\centering
 \\textbf{Generated: \\DTMnow}\\\\[1em]

--- a/javascript/parseXmlHtml.js
+++ b/javascript/parseXmlHtml.js
@@ -1,6 +1,4 @@
-import path from "path";
 import { getChildrenByTagName, ancestorHasTag } from "./utilityFunctions";
-import { checkIndexBadEndWarning } from "./processingFunctions/warnings.js";
 import { allFilepath, tableOfContent } from "./index.js";
 import {
   html_links_part1,
@@ -187,7 +185,7 @@ const processTextFunctionsDefaultHtml = {
 
   FIGURE: (node, writeTo) => {
     recursiveProcessTextHtml(node.firstChild, writeTo);
-    processFigureHtml(node, writeTo, chapArrIndex, snippet_count, false);
+    processFigureHtml(node, writeTo);
   },
 
   FOOTNOTE: (node, writeTo) => {
@@ -523,11 +521,6 @@ const processTextFunctionsSplit = {
     writeTo.push(`<span style="color:blue">`);
     recursiveProcessTextHtml(node.firstChild, writeTo);
     writeTo.push(`</span>`);
-  },
-
-  FIGURE: (node, writeTo) => {
-    recursiveProcessTextHtml(node.firstChild, writeTo);
-    processFigureHtml(node, writeTo, chapArrIndex, snippet_count, true);
   },
 
   SPLIT: (node, writeTo) => {

--- a/javascript/parseXmlHtml_split.js
+++ b/javascript/parseXmlHtml_split.js
@@ -1,6 +1,4 @@
-import path from "path";
-import { getChildrenByTagName, ancestorHasTag } from "./utilityFunctions";
-import { checkIndexBadEndWarning } from "./processingFunctions/warnings.js";
+import { getChildrenByTagName } from "./utilityFunctions";
 import { allFilepath, tableOfContent } from "./index.js";
 import {
   html_links_part1,

--- a/javascript/parseXmlJs.js
+++ b/javascript/parseXmlJs.js
@@ -1,6 +1,5 @@
 import path from "path";
 import fs from "fs";
-import util from "util";
 
 import { processSnippetJs } from "./processingFunctions";
 

--- a/javascript/parseXmlLatexSplit.js
+++ b/javascript/parseXmlLatexSplit.js
@@ -1,5 +1,4 @@
 import { getChildrenByTagName, ancestorHasTag } from "./utilityFunctions";
-import { checkIndexBadEndWarning } from "./processingFunctions/warnings.js";
 
 import {
   replaceTagWithSymbol,

--- a/javascript/processingFunctions/index.js
+++ b/javascript/processingFunctions/index.js
@@ -1,9 +1,9 @@
 import replaceTagWithSymbol from "./replaceTagWithSymbol";
-import { getChildrenByTagName, ancestorHasTag } from "../utilityFunctions";
+import { getChildrenByTagName } from "../utilityFunctions";
 import processFileInput from "./processFileInput";
 import recursiveProcessPureText from "./recursiveProcessPureText";
 
-import { recursiveProcessTextLatex, processTextLatex } from "../parseXmlLatex";
+import { recursiveProcessTextLatex } from "../parseXmlLatex";
 import processEpigraphPdf from "./processEpigraphPdf";
 import processExercisePdf from "./processExercisePdf";
 import processExerciseEpub from "./processExerciseEpub";
@@ -14,7 +14,6 @@ import processSnippetEpub from "./processSnippetEpub";
 import processSnippetJs from "./processSnippetJs";
 import processTablePdf from "./processTablePdf";
 
-import { recursiveProcessTextHtml, processTextHtml } from "../parseXmlHtml";
 import processEpigraphHtml from "./processEpigraphHtml";
 import processBlockquoteHtml from "./processBlockquoteHtml";
 import processExerciseHtml from "./processExerciseHtml";

--- a/javascript/processingFunctions/processExerciseEpub.js
+++ b/javascript/processingFunctions/processExerciseEpub.js
@@ -1,5 +1,5 @@
-import { recursiveProcessTextLatex, processTextLatex } from "../parseXmlLatex";
-import { getChildrenByTagName, ancestorHasTag } from "../utilityFunctions";
+import { recursiveProcessTextLatex } from "../parseXmlLatex";
+import { getChildrenByTagName } from "../utilityFunctions";
 
 let unlabeledEx = 0;
 const processExerciseEpub = (node, writeTo) => {

--- a/javascript/processingFunctions/processExerciseHtml.js
+++ b/javascript/processingFunctions/processExerciseHtml.js
@@ -1,5 +1,4 @@
-import { recursiveProcessTextHtml, processTextHtml } from "../parseXmlHtml";
-import { getChildrenByTagName, ancestorHasTag } from "../utilityFunctions";
+import { recursiveProcessTextHtml } from "../parseXmlHtml";
 import { missingExerciseWarning } from "./warnings.js";
 import { referenceStore } from "./processReferenceHtml";
 

--- a/javascript/processingFunctions/processExercisePdf.js
+++ b/javascript/processingFunctions/processExercisePdf.js
@@ -1,5 +1,5 @@
-import { recursiveProcessTextLatex, processTextLatex } from "../parseXmlLatex";
-import { getChildrenByTagName, ancestorHasTag } from "../utilityFunctions";
+import { recursiveProcessTextLatex } from "../parseXmlLatex";
+import { getChildrenByTagName } from "../utilityFunctions";
 
 let unlabeledEx = 0;
 const processExercisePdf = (node, writeTo) => {

--- a/javascript/processingFunctions/processFigureEpub.js
+++ b/javascript/processingFunctions/processFigureEpub.js
@@ -1,4 +1,4 @@
-import { recursiveProcessTextLatex, processTextLatex } from "../parseXmlLatex";
+import { recursiveProcessTextLatex } from "../parseXmlLatex";
 
 export const processFigureEpub = (node, writeTo) => {
   writeTo.push("\n\\begin{figure}[H]\n\\centering\n");

--- a/javascript/processingFunctions/processFigureHtml.js
+++ b/javascript/processingFunctions/processFigureHtml.js
@@ -1,19 +1,13 @@
 import {
   recursiveProcessTextHtml,
   processTextHtml,
-  processTextFunctionsHtml,
   toIndexFolder
 } from "../parseXmlHtml";
-import { getChildrenByTagName, ancestorHasTag } from "../utilityFunctions";
-import { processSnippetHtml, processSnippetHtmlScheme } from ".";
 import { referenceStore } from "./processReferenceHtml";
 
 export const processFigureHtml = (
   node,
-  writeTo,
-  chapArrIndex,
-  snippet_count,
-  split
+  writeTo
 ) => {
   let src = node.getAttribute("src");
   if (!src && node.getElementsByTagName("FIGURE")[0]) {

--- a/javascript/processingFunctions/processFigurePdf.js
+++ b/javascript/processingFunctions/processFigurePdf.js
@@ -1,5 +1,4 @@
-import { recursiveProcessTextLatex, processTextLatex } from "../parseXmlLatex";
-import { ancestorHasTag } from "../utilityFunctions";
+import { recursiveProcessTextLatex } from "../parseXmlLatex";
 import { processSnippetPdf } from ".";
 import { processTablePdf } from ".";
 

--- a/javascript/processingFunctions/processReferenceHtml.js
+++ b/javascript/processingFunctions/processReferenceHtml.js
@@ -1,12 +1,7 @@
 import { repeatedRefNameWarning, missingReferenceWarning } from "./warnings.js";
 import { allFilepath, tableOfContent } from "../index.js";
-import {
-  tagsToRemove,
-  toIndexFolder,
-  recursiveProcessTextHtml,
-  processTextHtml
-} from "../parseXmlHtml";
-import { getChildrenByTagName, ancestorHasTag } from "../utilityFunctions";
+import { tagsToRemove } from "../parseXmlHtml";
+import { ancestorHasTag } from "../utilityFunctions";
 
 export const referenceStore = {};
 

--- a/javascript/processingFunctions/processSnippetEpub.js
+++ b/javascript/processingFunctions/processSnippetEpub.js
@@ -7,7 +7,6 @@ import {
   missingExampleWarning,
   repeatedNameWarning
 } from "./warnings.js";
-import { recursiveProcessTextLatex, processTextLatex } from "../parseXmlLatex";
 import recursiveProcessPureText from "./recursiveProcessPureText";
 
 const snippetStore = {};

--- a/javascript/processingFunctions/processSnippetHtml.js
+++ b/javascript/processingFunctions/processSnippetHtml.js
@@ -1,16 +1,11 @@
 import { sourceAcademyURL } from "../constants";
 import lzString from "lz-string";
 import {
-  checkLongLineWarning,
   missingRequireWarning,
   missingExampleWarning,
   repeatedNameWarning
 } from "./warnings.js";
-import {
-  chapterIndex,
-  recursiveProcessTextHtml,
-  processTextHtml
-} from "../parseXmlHtml";
+import { chapterIndex } from "../parseXmlHtml";
 import recursiveProcessPureText from "./recursiveProcessPureText";
 
 const snippetStore = {};

--- a/javascript/processingFunctions/processSnippetJs.js
+++ b/javascript/processingFunctions/processSnippetJs.js
@@ -1,6 +1,4 @@
-import lzString from "lz-string";
 import {
-  checkLongLineWarning,
   missingRequireWarning,
   missingExampleWarning,
   repeatedNameWarning

--- a/javascript/processingFunctions/processTablePdf.js
+++ b/javascript/processingFunctions/processTablePdf.js
@@ -1,4 +1,4 @@
-import { recursiveProcessTextLatex, processTextLatex } from "../parseXmlLatex";
+import { recursiveProcessTextLatex } from "../parseXmlLatex";
 
 export const processTable = (node, writeTo) => {
   const firstRow = node.getElementsByTagName("TR")[0];


### PR DESCRIPTION
- Removed unused imports
- Remove unused parameters in `processFigureHtml`
    - `chapArrIndex`, `snippet_count` and `split` are no longer used
- Remove duplicate code in 'parseXmlHtml.js`
    - Function to handle `FIGURE` was duplicated twice at line 188 and line 528