### PR TITLE
Julie 12/6 comments

### DIFF
--- a/xml/chapter4/section3/subsection3.xml
+++ b/xml/chapter4/section3/subsection3.xml
@@ -1905,10 +1905,6 @@ if (evaluation_succeeds_take) { $statement$ } else { $alternative$ }
 	however, the given alternative statement 
 	is evaluated, as in the following example:
 	<SNIPPET EVAL="no">
-	  <JAVASCRIPT>
-	  </JAVASCRIPT>
-	</SNIPPET>
-	<SNIPPET EVAL="no">
 	  <JAVASCRIPT_PROMPT>
 amb-evaluate input:
 	  </JAVASCRIPT_PROMPT>

--- a/xml/chapter4/section4/subsection1.xml
+++ b/xml/chapter4/section4/subsection1.xml
@@ -2209,7 +2209,7 @@ rule(next_to_in($x, $y, pair($v, $z)),
       </JAVASCRIPT>
     </SNIPPET>
     What will the response be to the following queries?
-    <SNIPPET EVAL="no">
+    <SNIPPET EVAL="no" POSTPADDING="no">
       <SCHEME>
 (?x next-to ?y in (1 (2 3) 4))
 


### PR DESCRIPTION
> p.406 exercise 4.51
> Large vertical space between "The construct..." and the example code.

> p.421: extra space between ex 4.60 and 4.61

@martin-henz Did I miss anything when removing the empty SNIPPET? 