### PR TITLE
Comments in controller sequences in figures 5.9-5.12

### DIFF
--- a/xml/chapter5/section1/subsection3.xml
+++ b/xml/chapter5/section1/subsection3.xml
@@ -217,14 +217,14 @@ after-gcd-2
   branch(label("after_gcd_1")),
   go_to(label("after_gcd_2")),
   $\vdots$
-  // Before branching to "gcd" from the first place where
-  // it is needed, we place 0 in the "continue" register
+  // Before branching to gcd from the first place where
+  // it is needed, we place 0 in the continue register
   assign("continue", constant(0)),
   go_to(label("gcd")),
 "after_gcd_1",
   $\vdots$
-  // Before the second use of "gcd", we place 1 in the
-  // "continue" register
+  // Before the second use of gcd, we place 1 in the
+  // continue register
   assign("continue", constant(1)),
   go_to(label("gcd")),
 "after_gcd_2"
@@ -272,13 +272,13 @@ after-gcd-2
 "gcd_done",
   go_to(reg("continue")),
   $\vdots$
-  // Before calling "gcd", we assign to "continue"
-  // the label to which "gcd" should return.
+  // Before calling gcd, we assign to continue
+  // the label to which gcd should return.
   assign("continue", label("after_gcd_1"))),
   go_to(label("gcd")),
 "after_gcd_1",
   $\vdots$
-  // Here is the second call to "gcd", with a different continuation.
+  // Here is the second call to gcd, with a different continuation.
   assign("continue", label("after_gcd_2")),
   go_to(label("gcd")),
 "after_gcd_2"

--- a/xml/chapter5/section1/subsection4.xml
+++ b/xml/chapter5/section1/subsection4.xml
@@ -391,7 +391,7 @@ function fib(n) {
 	<FIGURE> 
 	  <FIGURE src="img_javascript/Fig5.11b.std.svg"/> 
 <PDF_ONLY>\flushleft</PDF_ONLY>
-          <SNIPPET>
+          <SNIPPET LATEX="yes">
 	    <NAME>factorial_recursive_controller</NAME>
 	    <EXAMPLE>factorial_recursive_example</EXAMPLE>
 	    <EXPECTED>24</EXPECTED>
@@ -402,9 +402,9 @@ controller(
     "fact_loop",
       test(list(op("="), reg("n"), constant(1))),
       branch(label("base_case")),
-      // Set up for recursive call by saving "n" and "continue".
-      // Set up "continue" so that the computation will continue
-      // at "after_fact" when the subroutine returns.
+      // Set up for recursive call by saving n and continue.
+      // Set up continue so that the computation will continue
+      // at after_fact when the subroutine returns.
       save("continue"),
       save("n"),
       assign("n", list(op("-"), reg("n"), constant(1))),
@@ -413,7 +413,7 @@ controller(
     "after_fact",
       restore("n"),
       restore("continue"),
-      assign("val",                   // "val" now contains n(n-1)!
+      assign("val",                   // val now contains ^$n(n-1)!$^
              list(op("*"), reg("n"), reg("val"))),  
       go_to(reg("continue")),         // return to caller
     "base_case",
@@ -461,7 +461,7 @@ const factorial_recursive_controller =
     </SPLIT>
     <!--  %(registers n val continue) %(operations &lt; - +) -->
     <FIGURE CENTER="no">
-      <SNIPPET>
+      <SNIPPET LATEX="yes">
 	<NAME>fib_recursive_controller</NAME>
 	<EXAMPLE>fib_recursive_example</EXAMPLE>
 	<EXPECTED>8</EXPECTED>
@@ -508,27 +508,27 @@ controller(
     // set up to compute Fib(n-1)
     save("continue"),
     assign("continue", label("afterfib_n_1")),
-    save("n"),                     // save old value of n
-    assign("n", list(op("-"), reg("n"), constant(1))), // clobber n to n-1 
+    save("n"),                     // save old value of ^{\tt n}^
+    assign("n", list(op("-"), reg("n"), constant(1))), // clobber ^{\tt n}^ to ^$n-1$^
     go_to(label("fib_loop")),      // perform recursive call
-  "afterfib_n_1",                  // upon return, "val" contains Fib(n-1)
+  "afterfib_n_1",                  // upon return, ^{\tt val}^ contains ^\rm Fib($n-1$)^
     restore("n"),
     restore("continue"),
-    // set up to compute Fib(n-2)
+    // set up to compute Fib(^$n-2$^)
     assign("n", list(op("-"), reg("n"), constant(2))),
     save("continue"),
     assign("continue", label("afterfib_n_2")),
-    save("val"),                   // save Fib(n-1)
+    save("val"),                   // save ^Fib($n-1$)^
     go_to(label("fib_loop")),
-  "afterfib_n_2",                  // upon return, val is Fib(n-2)
-    assign("n", reg("val")),       // n now contains Fib(n-2)
-    restore("val"),                // val now contains Fib(n-1)
+  "afterfib_n_2",                  // upon return, ^{\tt val}^ is ^\rm Fib($n-2$)^
+    assign("n", reg("val")),       // ^{\tt n}^ now contains ^\rm Fib($n-2$)^
+    restore("val"),                // ^{\tt val}^ now contains ^\rm Fib($n-1$)^
     restore("continue"),
-    assign("val",                  // Fib(n-1) + Fib(n-2)
+    assign("val",                  // ^\rm Fib($n-1$)^ + ^\rm Fib($n-2$)^
       list(op("+"), reg("val"), reg("n"))),
-    go_to(reg("continue")),        // return to caller, answer in val
+    go_to(reg("continue")),        // return to caller, answer in ^{\tt val}^
   "immediate_answer",
-    assign("val", reg("n")),       // base case: Fib(n) = n
+    assign("val", reg("n")),       // base case: ^\rm Fib($n$) $=$ $n$^
     go_to(reg("continue")),
   "fib_done"))
 	</JAVASCRIPT>


### PR DESCRIPTION
> Labels and registers should be in code font without ""
> That is, the same way they appear in the text.
>
>    5.9: gcd, continue, gcd continue
>       5.10: gcd, continue, gcd, gcd
>          5.11: n, continiue, continue, after_fact, val
>
>    5.12:
>        clobber N to n-1 [the n-1 is correctly math font]
>            upon return, VAL contains...
> 	       upon return, VAL CONTAINS
> 	               -- change IS to CONTAINS as in the other
> 		       comments
> 		           N now contains
> 			       VAL now contains
> 			           return...answer in VAL
>
>     In 5.12, this one is code font in SICP
>           save old value of N
> 	      but you might argue that it's talking about the
> 	      math/value and
> 	            and that math font for the n is also correct and
> 		    fits well
> 		          with the next comment, which is clobber N to
> 			  n-1
> 			           where N is clearly the register and
> 				   n-1 is correctly math font
>
>