### PR TITLE
JSON: replace` \mbox` with `\text`

### DIFF
--- a/javascript/parseXmlJson.js
+++ b/javascript/parseXmlJson.js
@@ -277,12 +277,12 @@ const processTextFunctions = {
 
   LATEXINLINE: (node, obj) => {
     const writeTo = [];
-    recursiveProcessPureText(node.firstChild, writeTo, {
-      removeNewline: "all"
-    });
+    recursiveProcessPureText(node.firstChild, writeTo);
 
     let math = "";
     writeTo.forEach(x => (math += x));
+
+    math = math.replace(/mbox/g, "text"); //replace mbox with text
 
     addBodyToObj(obj, node, math);
   },

--- a/javascript/parseXmlJson.js
+++ b/javascript/parseXmlJson.js
@@ -273,16 +273,28 @@ const processTextFunctions = {
     obj["href"] = node.getAttribute("address");
   },
 
-  LATEX: (node, obj) => processTextFunctions["LATEXINLINE"](node, obj),
-
-  LATEXINLINE: (node, obj) => {
+  LATEX: (node, obj) => {
     const writeTo = [];
     recursiveProcessPureText(node.firstChild, writeTo);
 
     let math = "";
     writeTo.forEach(x => (math += x));
 
-    math = math.replace(/mbox/g, "text"); //replace mbox with text
+    math = math.replace(/mbox/g, "text"); // replace mbox with text
+
+    addBodyToObj(obj, node, math);
+  },
+
+  LATEXINLINE: (node, obj) => {
+    const writeTo = [];
+    recursiveProcessPureText(node.firstChild, writeTo, {
+      removeNewline: "all"
+    });
+
+    let math = "";
+    writeTo.forEach(x => (math += x));
+
+    math = math.replace(/mbox/g, "text"); // replace mbox with text
 
     addBodyToObj(obj, node, math);
   },


### PR DESCRIPTION
This small pr changes `\mbox` in LaTeX equations to `\text`. I am trying to replace MathJax with another library (see this [PR](https://github.com/source-academy/cadet-frontend/pull/1801) for the cadet frontend (KaTeX) that is much faster, but does not support `\mbox`.

The output seems to be the same.
Before:
<img width="344" alt="Screenshot 2021-06-17 at 10 42 31 PM" src="https://user-images.githubusercontent.com/60355570/122419200-55316080-cfbd-11eb-9021-6d826f367d52.png">

After:
<img width="366" alt="Screenshot 2021-06-17 at 10 41 46 PM" src="https://user-images.githubusercontent.com/60355570/122419108-45198100-cfbd-11eb-8808-09e22a686cdd.png">
