### PR TITLE
Fix minor issues

### DIFF
--- a/javascript/parseXmlJson.js
+++ b/javascript/parseXmlJson.js
@@ -205,7 +205,6 @@ const processTextFunctions = {
 
   EXERCISE: (node, obj) => {
     exercise_count += 1;
-    addBodyToObj(obj, node, false);
     processExerciseJson(node, obj, chapArrIndex, exercise_count);
   },
 

--- a/javascript/parseXmlJson.js
+++ b/javascript/parseXmlJson.js
@@ -128,6 +128,11 @@ const processTextFunctions = {
     obj["tag"] = "#text";
   },
 
+  DOLLAR: (node, obj) => {
+    addBodyToObj(obj, node, "$");
+    obj["tag"] = "#text";
+  },
+
   B: (node, obj) => {
     addBodyToObj(obj, node, false);
     recursiveProcessTextJson(node.firstChild, obj);

--- a/javascript/processingFunctions/processExerciseJson.js
+++ b/javascript/processingFunctions/processExerciseJson.js
@@ -22,6 +22,7 @@ const processExerciseHtml = (node, obj) => {
 
   const displayName = referenceStore[labelName].displayName;
 
+  obj["tag"] = "EXERCISE";
   obj["title"] = "Exercise " + displayName;
   obj["id"] = `#ex-${displayName}`;
 

--- a/xml/others/05acknowledgements05.xml
+++ b/xml/others/05acknowledgements05.xml
@@ -114,8 +114,9 @@ Shyu.
 <TEXT>
 Beyond the MIT implementation, we would like to thank the many people
 who worked on the IEEE Scheme standard, including William Clinger and
-Jonathan Rees, who edited the R$^4$RS, and Chris Haynes, David
-Bartley, Chris Hanson, and Jim Miller, who prepared the IEEE standard.
+Jonathan Rees, who edited the R<LATEXINLINE>$^4$</LATEXINLINE>RS,
+and Chris Haynes, David Bartley, Chris Hanson, and Jim Miller,
+who prepared the IEEE standard.
 </TEXT>
 <TEXT>
 Dan Friedman has been a long-time leader of the Scheme community.


### PR DESCRIPTION
1) Add `LATEXINLINE` tag to acknowledgements xml page. Previously, `$` math delimiters were not being recognised on interactive sicp.

2) Replace `DOLLAR` tag with  `$` in json version.

3) Remove empty exercises from json version.