### PR TITLE
Add prepend length to json

### DIFF
--- a/javascript/processingFunctions/processSnippetJson.js
+++ b/javascript/processingFunctions/processSnippetJson.js
@@ -225,9 +225,13 @@ export const processSnippetJson = (node, snippet) => {
         "chap=" + chap + variant + ext + "&prgrm=" + program;
 
       if (reqStr) {
-        addToSnippet("program", makeHash(compressed), snippet);
         addToSnippet("prepend", compressedPrepend, snippet);
+        addToSnippet("prependLength", reqStr.split('\n').length, snippet);
+      } else {
+        addToSnippet("prependLength", 0, snippet);
       }
+
+      addToSnippet("program", makeHash(compressed), snippet);
 
       addToSnippet(
         "withoutPrepend",


### PR DESCRIPTION
Context: I'm working on changing the way dependencies in snippets are hidden to utilise code folding instead. My previous implementation where I evaluated the dependencies as the prepend has been plagued with issues (snippets not working properly, env viz not working when dependencies are hidden etc). 

1. `prependLength`, the length of prepend added to json to prepare to rework way dependencies in snippets are hidden.

2. `withoutPrepend` and `prepend` fields are not longer needed, but we should leave it there for a couple of days so we do not break older versions of source academy. I'll remove these in a future pr a couple of days after the frontend changes are pushed.