### PR TITLE
JSON: Refactor parsing of SECTION tag

### DIFF
--- a/javascript/parseXmlJson.js
+++ b/javascript/parseXmlJson.js
@@ -196,7 +196,7 @@ const processTextFunctions = {
     parent.appendChild(cloneNode);
 
     obj["tag"] = "FOOTNOTE_REF";
-    obj["id"] = `footnote-link-${footnote_count}`;
+    obj["id"] = `#footnote-link-${footnote_count}`;
     obj["body"] = `${footnote_count}`;
     obj["href"] = `/sicpjs/${chapterIndex}#footnote-${footnote_count}`;
   },

--- a/javascript/processingFunctions/processReferenceJson.js
+++ b/javascript/processingFunctions/processReferenceJson.js
@@ -140,15 +140,8 @@ export const processReferenceJson = (node, obj, chapterIndex) => {
   if (ref_type == "foot") {
     obj["tag"] = "FOOTNOTE_REF";
     obj["id"] = `${chapterIndex}-foot-link-${displayName}`;
-  } else if (ref_type == "ex") {
+  } else {
     obj["tag"] = "REF";
-    obj["id"] = `${chapterIndex}-ex-link-${displayName}`;
-  } else if (ref_type == "fig") {
-    obj["tag"] = "REF";
-    obj["id"] = `${chapterIndex}-fig-link-${displayName}`;
-  } else if (ref_type == "sec") {
-    obj["tag"] = "REF";
-    obj["id"] = `${chapterIndex}-sec-link-${displayName}`;
   }
 
   obj["body"] = displayName;

--- a/javascript/processingFunctions/processReferenceJson.js
+++ b/javascript/processingFunctions/processReferenceJson.js
@@ -23,7 +23,6 @@ const ifIgnore = node => {
 };
 
 export const setupReferencesJson = (node, filename) => {
-  const chapArrIndex = allFilepath.indexOf(filename);
   const chapterIndex = tableOfContent[filename].index;
 
   subsubsection_count = 0;


### PR DESCRIPTION
- `SECTION` TAG (and equivalent) are not parsed in two steps, first the title then the rest of the body. This simplifies the resulting json output.
- Removed dead code in `processReferenceJson.js`