### PR TITLE
Fix broken inline LaTeX in web edition

### DIFF
--- a/xml/chapter4/section1/subsection2.xml
+++ b/xml/chapter4/section1/subsection2.xml
@@ -434,10 +434,12 @@ list("sequence",
 	the actual value.
 	<WEB_ONLY>
 	  <LATEX>
-	    \begin{eqnarray*}
-	    \ll\ \mathit{literal}\textit{-}\mathit{expression}\ \gg &amp; = &amp;
+	    \[
+      \begin{align*}
+	    \ll\ \mathit{literal}\textit{-}\mathit{expression}\ \gg &amp; = 
 	    \texttt{list("literal", }\mathit{value}\texttt{)}
-	    \end{eqnarray*}
+	    \end{align*}
+      \]
 	  </LATEX>
 	  where <META>value</META> is
 	  the JavaScript value represented by the
@@ -589,10 +591,12 @@ function make_literal(value) {
     element and the string representing the name as second element.
     <WEB_ONLY>
 	<LATEX>
-	  \begin{eqnarray*}
-	  \ll\ \mathit{name}\ \gg &amp; = &amp;
+    \[
+	  \begin{align*}
+	  \ll\ \mathit{name}\ \gg &amp; = 
 	  \texttt{list("name", }\mathit{symbol}\texttt{)}
-	  \end{eqnarray*}
+	  \end{align*}
+    \]
 	</LATEX>
 	where <META>symbol</META> is a string
 	that contains the characters that make up the
@@ -673,10 +677,9 @@ function make_name(symbol) {
     between the two kinds of components:
     <WEB_ONLY>
 	<LATEX>
-	  \begin{eqnarray*}
-	  \ll\ \mathit{expression}\texttt{;}\ \gg &amp; = &amp;
-	  \ll\ \mathit{expression}\ \gg
-	  \end{eqnarray*}
+	  \[
+    \ll\ \mathit{expression}\texttt{;}\ \gg {=} \ll\ \mathit{expression}\ \gg
+    \]
 	</LATEX>
     </WEB_ONLY>
     <PDF_ONLY>
@@ -701,11 +704,11 @@ function make_name(symbol) {
     are parsed as follows:
     <WEB_ONLY>
 	<LATEX>
-	  \begin{eqnarray*}
-&amp;	  \ll\ \mathit{fun}\textit{-}\mathit{expr}\texttt{(}\mathit{arg}\textit{-}\mathit{expr}_1\texttt{, }\ldots\texttt{, } \mathit{arg}\textit{-}\mathit{expr}_n \texttt{)}\ \gg \\
-&amp;	  = \\
-&amp;	  \texttt{list("application",} \ll\ \mathit{fun}\textit{-}\mathit{expr}\gg\texttt{, list(} \ll\ \mathit{arg}\textit{-}\mathit{expr}_1\;\gg \texttt{, }\ldots\texttt{, } \ll\ \mathit{arg}\textit{-}\mathit{expr}_n\;\gg \texttt{))}
-	  \end{eqnarray*}
+    \[
+    \ll\ \mathit{fun}\textit{-}\mathit{expr}\texttt{(}\mathit{arg}\textit{-}\mathit{expr}_1\texttt{, }\ldots\texttt{, } \mathit{arg}\textit{-}\mathit{expr}_n \texttt{)}\ \gg \\
+    = \\
+    \texttt{list("application",} \ll\ \mathit{fun}\textit{-}\mathit{expr}\gg\texttt{, list(} \ll\ \mathit{arg}\textit{-}\mathit{expr}_1\;\gg \texttt{, }\ldots\texttt{, } \ll\ \mathit{arg}\textit{-}\mathit{expr}_n\;\gg \texttt{))}
+    \]
 	</LATEX>
     </WEB_ONLY>
     <PDF_ONLY>
@@ -908,11 +911,11 @@ conditional_alternative(my_cond_expr);
     return expression is the body of the lambda expression.
     <WEB_ONLY>
     <LATEX>
-\begin{eqnarray*}      
-&amp; \ll\ \texttt{(}\mathit{name}_1\texttt{, }\ldots\texttt{, } \mathit{name}_n \texttt{) =&gt;}\ \mathit{expression}\ \gg \\
-&amp; = \\
-&amp; \ll\ \texttt{(}\mathit{name}_1\texttt{, }\ldots\texttt{, } \mathit{name}_n \texttt{) =&gt; \{}\ \textbf{return} \ \mathit{expression}\texttt{;}\ \texttt{\}}\ \gg
-\end{eqnarray*}
+\[
+ \ll\ \texttt{(}\mathit{name}_1\texttt{, }\ldots\texttt{, } \mathit{name}_n \texttt{) =&gt;}\ \mathit{expression}\ \gg \\
+ = \\
+ \ll\ \texttt{(}\mathit{name}_1\texttt{, }\ldots\texttt{, } \mathit{name}_n \texttt{) =&gt; \{}\ \textbf{return} \ \mathit{expression}\texttt{;}\ \texttt{\}}\ \gg
+\]
 	</LATEX>
     </WEB_ONLY>
     <PDF_ONLY>
@@ -1033,13 +1036,13 @@ function make_lambda_expression(parameters, body) {
     single statement. A<SPACE/>sequence of statements is parsed as follows:
     <WEB_ONLY>
     <LATEX>
-	  \begin{eqnarray*}
-&amp;	  \ll\ \mathit{statement}_1 \cdots \mathit{statement}_n\;\gg \\
-&amp;	  = \\
-&amp;	  \texttt{list("sequence", list(}
+\[
+\ll\ \mathit{statement}_1 \cdots \mathit{statement}_n\;\gg \\
+= \\
+\texttt{list("sequence", list(}
 \ll\ \mathit{statement}_1\;\gg \texttt{, } \ldots \texttt{, }
 \ll\ \mathit{statement}_n\;\gg \texttt{))}
-	  \end{eqnarray*}
+\]
     </LATEX>
     </WEB_ONLY>
     <PDF_ONLY>
@@ -1164,11 +1167,13 @@ list_ref(rest_statements(my_actions), 1);
     these decisions.</FOOTNOTE>
     <WEB_ONLY>
     <LATEX>
-	  \begin{eqnarray*}
+    \[
+	  \begin{align*}
 	  \ll\ \texttt{\{}\ \mathit{statements}\ \texttt{\}}\ \gg
-	  &amp; = &amp;
+	  &amp; =
 	  \texttt{list("block",}\ \ll\ \mathit{statements}\ \gg \texttt{)}
-	  \end{eqnarray*}
+	  \end{align*}
+    \]
 	  </LATEX>
     </WEB_ONLY>
     <PDF_ONLY>
@@ -1233,11 +1238,13 @@ display(block_body(my_block));
     are parsed as follows:
     <WEB_ONLY>
 	<LATEX>
-	  \begin{eqnarray*}
+    \[
+	  \begin{align*}
 	  \ll\ \textbf{return}\ \mathit{expression} \texttt{;}\ \gg
-	  &amp; = &amp;
-	  \texttt{list("return_statement",}\ \ll\ \mathit{expression}\ \gg \texttt{)}
-	  \end{eqnarray*}
+	  &amp; =
+	  \texttt{list("return\_statement",}\ \ll\ \mathit{expression}\ \gg \texttt{)}
+	  \end{align*}
+    \]
 	</LATEX>
     </WEB_ONLY>
     <PDF_ONLY>
@@ -1290,10 +1297,12 @@ list_ref(my_return, 1);
     are parsed as follows:
     <WEB_ONLY>
 	<LATEX>
-	  \begin{eqnarray*}
-	  \ll\ \mathit{name}\ \ \texttt{=}\ \ \mathit{expression}\ \gg &amp; = &amp;
+    \[
+	  \begin{align*}
+	  \ll\ \mathit{name}\ \ \texttt{=}\ \ \mathit{expression}\ \gg &amp; = 
 	  \texttt{list("assignment", }\ll\ \mathit{name}\gg \texttt{, }\ll\ \mathit{expression}\ \gg \texttt{)}
-	  \end{eqnarray*}
+	  \end{align*}
+    \]
 	</LATEX>
     </WEB_ONLY>
     <PDF_ONLY>
@@ -1366,14 +1375,14 @@ assignment_value_expression(my_assignment_statement);
       are parsed as follows:
       <WEB_ONLY>
 	<LATEX>
-	  \begin{eqnarray*}
-&amp;  \ll\ \textbf{const}\ \mathit{name}\ \ \texttt{=}\ \ \mathit{expression}\texttt{;}\ \gg \\
-&amp; = \\
-&amp; \texttt{list("constant_declaration", } \ll\ \mathit{name}\ \gg \texttt{, }\ll\ \mathit{expression}\ \gg \texttt{)}\\[3mm]
-&amp;  \ll\ \textbf{let}\ \mathit{name} \ \ \texttt{=}\ \ \mathit{expression}\texttt{;}\ \gg \\
-&amp; = \\
-&amp; \texttt{list("variable_declaration", } \ll\ \mathit{name}\ \gg \texttt{, }\ll\ \mathit{expression}\ \gg \texttt{)}
-	  \end{eqnarray*}
+\[
+  \ll\ \textbf{const}\ \mathit{name}\ \ \texttt{=}\ \ \mathit{expression}\texttt{;}\ \gg \\
+  = \\
+  \texttt{list("constant\_declaration", } \ll\ \mathit{name}\ \gg \texttt{, }\ll\ \mathit{expression}\ \gg \texttt{)}\\[3mm]
+  \ll\ \textbf{let}\ \mathit{name} \ \ \texttt{=}\ \ \mathit{expression}\texttt{;}\ \gg \\
+  = \\
+  \texttt{list("variable\_declaration", } \ll\ \mathit{name}\ \gg \texttt{, }\ll\ \mathit{expression}\ \gg \texttt{)}
+\]
 	</LATEX>
       </WEB_ONLY>
       <PDF_ONLY>
@@ -1723,12 +1732,12 @@ function function_decl_to_constant_decl(component) {
 	in the tagged-list representation:
 	<WEB_ONLY>
 	    <LATEX>
-	      \begin{eqnarray*}
-	      &amp; \ll\ \mathit{unary}\textit{-}\mathit{operator}\ \ \mathit{expression}\ \gg \\
-	      &amp; = \\
-	      &amp; \texttt{list("unary_operator_combination", "}\mathit{unary}\textit{-}\mathit{operator}\texttt{"},\ 
-              \texttt{list(}\ll\ \mathit{expression}\ \gg \texttt{))}
-	      \end{eqnarray*}
+	      \[
+	          \ll\ \mathit{unary}\textit{-}\mathit{operator}\ \ \mathit{expression}\ \gg \\
+	          = \\
+	          \texttt{list("unary\_operator\_combination", "}\mathit{unary}\textit{-}\mathit{operator}\texttt{"},\ 
+            \texttt{list(}\ll\ \mathit{expression}\ \gg \texttt{))}
+	      \]
 	    </LATEX>
 	</WEB_ONLY>
 	<PDF_ONLY>
@@ -1754,12 +1763,12 @@ $\ll\ $<META>unary-operator</META> <META>expression</META>$\ \gg$ =
     <JAVASCRIPTINLINE>-unary</JAVASCRIPTINLINE> (for numeric negation), and
     <WEB_ONLY>
 	    <LATEX>
-	      \begin{eqnarray*}
-	      &amp; \ll\ \mathit{expression}_1\ \mathit{binary}\textit{-}\mathit{operator}\ \ \mathit{expression}_2\;\gg \\
-	      &amp; = \\
-	      &amp; \texttt{list("binary_operator_combination", "}\mathit{binary}\textit{-}\mathit{operator}\texttt{"},\ 
-              \texttt{list(}\ll\ \mathit{expression}_1\;\gg\texttt{,}\ \ll\ \mathit{expression}_2\;\gg \texttt{))}
-	      \end{eqnarray*}
+	      \[
+	          \ll\ \mathit{expression}_1\ \mathit{binary}\textit{-}\mathit{operator}\ \ \mathit{expression}_2\;\gg \\
+	          = \\
+	          \texttt{list("binary\_operator\_combination", "}\mathit{binary}\textit{-}\mathit{operator}\texttt{"},\\ 
+            \texttt{list(}\ll\ \mathit{expression}_1\;\gg\texttt{,}\ \ll\ \mathit{expression}_2\;\gg \texttt{))}
+	      \]
 	    </LATEX>
     </WEB_ONLY>
     <PDF_ONLY>


### PR DESCRIPTION
Fixes #560 

- Add `\[` and `\]`math delimiters around latex
- Replace `eqnarray`, which the KaTeX library used by frontend does not support with `align` when needed.
- Escape underscores when needed.

Some screenshots of math from the web edition below:

<img width="695" alt="Screenshot 2021-07-09 at 5 29 01 PM" src="https://user-images.githubusercontent.com/60355570/125056780-29485d00-e0db-11eb-8691-85f194048060.png">


<img width="548" alt="Screenshot 2021-07-09 at 5 26 38 PM" src="https://user-images.githubusercontent.com/60355570/125056444-d2428800-e0da-11eb-94ca-600946e291aa.png">

<img width="737" alt="Screenshot 2021-07-09 at 5 33 29 PM" src="https://user-images.githubusercontent.com/60355570/125057448-d327e980-e0db-11eb-92c8-352371ecb60d.png">
