### PR TITLE
Support line break in inline code

### DIFF
--- a/javascript/parseXmlHtml.js
+++ b/javascript/parseXmlHtml.js
@@ -350,14 +350,22 @@ const processTextFunctionsDefaultHtml = {
 
   JAVASCRIPTINLINE: (node, writeTo) => {
     if (ancestorHasTag(node, "NAME")) {
-      recursiveProcessPureText(node.firstChild, writeTo, {
-        removeNewline: "all"
-      });
+      recursiveProcessPureText(
+        node.firstChild.data.replace(/@/g, ""),
+        writeTo,
+        {
+          removeNewline: "all"
+        }
+      );
     } else {
       writeTo.push("<kbd>");
-      recursiveProcessPureText(node.firstChild, writeTo, {
-        removeNewline: "all"
-      });
+      recursiveProcessPureText(
+        node.firstChild.data.replace(/@/g, ""),
+        writeTo,
+        {
+          removeNewline: "all"
+        }
+      );
       writeTo.push("</kbd>");
     }
   },

--- a/javascript/parseXmlHtml_split.js
+++ b/javascript/parseXmlHtml_split.js
@@ -291,7 +291,9 @@ export const processTextFunctionsHtml = {
 
   JAVASCRIPTINLINE: (node, writeTo) => {
     writeTo.push("<kbd>");
-    recursiveProcessPureText(node.firstChild, writeTo, { removeNewline: true });
+    recursiveProcessPureText(node.firstChild.data.replace(/@/g, ""), writeTo, {
+      removeNewline: true
+    });
     writeTo.push("</kbd>");
   },
 

--- a/javascript/parseXmlJson.js
+++ b/javascript/parseXmlJson.js
@@ -285,13 +285,21 @@ const processTextFunctions = {
   JAVASCRIPTINLINE: (node, obj) => {
     const writeTo = [];
     if (ancestorHasTag(node, "NAME")) {
-      recursiveProcessPureText(node.firstChild, writeTo, {
-        removeNewline: "all"
-      });
+      recursiveProcessPureText(
+        node.firstChild.data.replace(/@/g, ""),
+        writeTo,
+        {
+          removeNewline: "all"
+        }
+      );
     } else {
-      recursiveProcessPureText(node.firstChild, writeTo, {
-        removeNewline: "all"
-      });
+      recursiveProcessPureText(
+        node.firstChild.data.replace(/@/g, ""),
+        writeTo,
+        {
+          removeNewline: "all"
+        }
+      );
     }
     addArrayToObj(obj, node, writeTo);
     obj["tag"] = "JAVASCRIPTINLINE";

--- a/javascript/parseXmlLatex.js
+++ b/javascript/parseXmlLatex.js
@@ -555,6 +555,8 @@ const processTextFunctionsDefaultLatex = {
         );
       } else if (getChildrenByTagName(node, "META")[0]) {
         writeTo.push("{\\JSMathEscape~");
+      } else if (node.firstChild.data.search("@") >= 0) {
+        writeTo.push("{\\JSBreak~");
       } else {
         writeTo.push("{\\JS~");
       }

--- a/javascript/parseXmlLatexSplit.js
+++ b/javascript/parseXmlLatexSplit.js
@@ -263,7 +263,7 @@ const processTextFunctionsDefaultLatex = {
     processTextFunctionsLatex["JAVASCRIPTINLINE"](node, writeTo),
   JAVASCRIPTINLINE: (node, writeTo) => {
     writeTo.push("{\\lstinline[mathescape=true]$");
-    recursiveProcessPureText(node.firstChild, writeTo, {
+    recursiveProcessPureText(node.firstChild.data.replace(/@/g, ""), writeTo, {
       removeNewline: "all"
     });
     writeTo.push("$}");

--- a/xml/chapter5/section2/subsection1.xml
+++ b/xml/chapter5/section2/subsection1.xml
@@ -228,7 +228,7 @@ function set_contents(register, value) {
     </SPLITINLINE>
     <SPLITINLINE>
       <SCHEME><SCHEMEINLINE>make-stack</SCHEMEINLINE></SCHEME>
-      <JAVASCRIPT><JAVASCRIPTINLINE>make_stack</JAVASCRIPTINLINE></JAVASCRIPT>
+      <JAVASCRIPT><JAVASCRIPTINLINE>make_@stack</JAVASCRIPTINLINE></JAVASCRIPT>
     </SPLITINLINE>
     creates a stack whose local state consists
     of a list of the items on the stack.  A stack accepts requests to

--- a/xml/chapter5/section2/subsection3.xml
+++ b/xml/chapter5/section2/subsection3.xml
@@ -341,14 +341,14 @@ function assign_value_exp(assign_instruction) {
     to produce the target register object.  The value expression is passed to
     <SPLITINLINE>
       <SCHEME><SCHEMEINLINE>make-operation-exp</SCHEMEINLINE></SCHEME>
-      <JAVASCRIPT><JAVASCRIPTINLINE>make_operation_exp_ef</JAVASCRIPTINLINE>
+      <JAVASCRIPT><JAVASCRIPTINLINE>make_@operation_@exp_@ef</JAVASCRIPTINLINE>
       </JAVASCRIPT>
     </SPLITINLINE>
     if the value is the result of an operation, and to
     <SPLITINLINE>
       <SCHEME><SCHEMEINLINE>make-primitive-exp</SCHEMEINLINE></SCHEME>
       <JAVASCRIPT>
-	<JAVASCRIPTINLINE>make_primitive_exp_ef</JAVASCRIPTINLINE>
+	<JAVASCRIPTINLINE>make_@primitive_@exp_@ef</JAVASCRIPTINLINE>
       </JAVASCRIPT>
     </SPLITINLINE>
     otherwise.  These
@@ -929,7 +929,7 @@ function perform_action(perform_instruction) {
     <SPLITINLINE>
       <SCHEME>(<SCHEMEINLINE>make-operation-exp</SCHEMEINLINE>,</SCHEME>
       <JAVASCRIPT>
-      (<JAVASCRIPTINLINE>make_operation_exp_ef</JAVASCRIPTINLINE>,</JAVASCRIPT>
+      (<JAVASCRIPTINLINE>make_@operation_@exp_@ef</JAVASCRIPTINLINE>,</JAVASCRIPT>
     </SPLITINLINE>
     below).  The following
     <SPLITINLINE>

--- a/xml/chapter5/section4/subsection1.xml
+++ b/xml/chapter5/section4/subsection1.xml
@@ -717,7 +717,7 @@ compound-apply
         The portion of the explicit-control evaluator beginning at
         <JAVASCRIPTINLINE>ev_sequence</JAVASCRIPTINLINE>, which handles
 	sequences of statements. is analogous to the metacircular evaluator's
-        <JAVASCRIPTINLINE>eval_sequence</JAVASCRIPTINLINE> function.  
+        <JAVASCRIPTINLINE>eval_@sequence</JAVASCRIPTINLINE> function.  
       </TEXT>
       <TEXT>
         The entries at <JAVASCRIPTINLINE>ev_sequence_next</JAVASCRIPTINLINE> and

--- a/xml/chapter5/section4/subsection2.xml
+++ b/xml/chapter5/section4/subsection2.xml
@@ -523,7 +523,7 @@ function is_last_argument_expression(arg_expression) {
       <TEXT>
         When a return statement is evaluated at
         <JAVASCRIPTINLINE>ev_return</JAVASCRIPTINLINE>, we use the
-        <JAVASCRIPTINLINE>revert_stack_to_marker</JAVASCRIPTINLINE> instruction to restore
+        <JAVASCRIPTINLINE>revert_stack_@to_marker</JAVASCRIPTINLINE> instruction to restore
         the stack to its state at the beginning of the function call by removing all
         values from the stack down to and including the marker. As a consequence,
         <JAVASCRIPTINLINE>restore("continue")</JAVASCRIPTINLINE> will restore the
@@ -892,7 +892,7 @@ function count(n) {
         using <JAVASCRIPTINLINE>save</JAVASCRIPTINLINE> at
         <JAVASCRIPTINLINE>compound_apply</JAVASCRIPTINLINE> to store a special marker
         value on the stack. Implement the equivalent of
-        <JAVASCRIPTINLINE>revert_stack_to_marker</JAVASCRIPTINLINE> at
+        <JAVASCRIPTINLINE>revert_@stack_@to_@marker</JAVASCRIPTINLINE> at
         <JAVASCRIPTINLINE>ev_return</JAVASCRIPTINLINE> and
         <JAVASCRIPTINLINE>return_undefined</JAVASCRIPTINLINE> as a loop that repeatedly
         performs a <JAVASCRIPTINLINE>restore</JAVASCRIPTINLINE> until it hits the

--- a/xml/chapter5/section4/subsection3.xml
+++ b/xml/chapter5/section4/subsection3.xml
@@ -88,7 +88,7 @@ ev-if-consequent
 	<INDEX>scanning out declarations<SUBINDEX>in register machine</SUBINDEX></INDEX>
 	<JAVASCRIPTINLINE>scan_out_declarations</JAVASCRIPTINLINE>
 	from section<SPACE/><REF NAME="sec:core-of-evaluator"/>. The functions
-  <JAVASCRIPTINLINE>scan_out_declarations</JAVASCRIPTINLINE> and
+  <JAVASCRIPTINLINE>scan_@out_@declarations</JAVASCRIPTINLINE> and
   <JAVASCRIPTINLINE>list_of_unassigned</JAVASCRIPTINLINE> are assumed
   to be available as machine operations.<FOOTNOTE>
 	Footnote<SPACE/><REF NAME="foot:syntax-transformer"/>

--- a/xml/chapter5/section4/subsection4.xml
+++ b/xml/chapter5/section4/subsection4.xml
@@ -170,10 +170,10 @@
       </SCHEME>
       <JAVASCRIPT>
         We store a global environment that we update each time around the loop to remember past declarations.
-        The 
-	<JAVASCRIPTINLINE>get_global_environment</JAVASCRIPTINLINE> and
-	<JAVASCRIPTINLINE>set_global_environment</JAVASCRIPTINLINE> operations
-	simply get and set the variable <JAVASCRIPTINLINE>the_global_environment</JAVASCRIPTINLINE>:
+        The operations
+	<JAVASCRIPTINLINE>get_@global_@environment</JAVASCRIPTINLINE> and
+	<JAVASCRIPTINLINE>set_@global_@environment</JAVASCRIPTINLINE> 
+	simply get and set the variable <JAVASCRIPTINLINE>the_@global_@environment</JAVASCRIPTINLINE>:
     <SNIPPET EVAL="no">
       <INDEX><DECLARATION>get_global_environment</DECLARATION></INDEX>
       <INDEX><DECLARATION>set_global_environment</DECLARATION></INDEX>

--- a/xml/chapter5/section5/section5.xml
+++ b/xml/chapter5/section5/section5.xml
@@ -574,7 +574,7 @@ assign("fun", list(op("lookup_symbol_value"), constant("f"), reg("env")))
     rather than performing the
     <SPLITINLINE>
       <SCHEME><SCHEMEINLINE>lookup-variable-value</SCHEMEINLINE></SCHEME>
-      <JAVASCRIPT><JAVASCRIPTINLINE>lookup_symbol_value</JAVASCRIPTINLINE>
+      <JAVASCRIPT><JAVASCRIPTINLINE>lookup_@symbol_@value</JAVASCRIPTINLINE>
       </JAVASCRIPT>
     </SPLITINLINE>
     search.  We will discuss how to implement such

--- a/xml/chapter5/section5/subsection2.xml
+++ b/xml/chapter5/section5/subsection2.xml
@@ -1059,7 +1059,7 @@ function compile_lambda_expression(exp, target, linkage) {
 	<SPLITINLINE>
 	  <SCHEME><SCHEMEINLINE>tack-on-instruction-sequence</SCHEMEINLINE></SCHEME>
 	  <JAVASCRIPT>
-	    <JAVASCRIPTINLINE>tack_on_instruction_sequence</JAVASCRIPTINLINE>
+	    <JAVASCRIPTINLINE>tack_@on_@instruction_@sequence</JAVASCRIPTINLINE>
 	  </JAVASCRIPT>
 	</SPLITINLINE>
 	(section<SPACE/><REF NAME="sec:combining-instruction-sequences"/>) rather
@@ -1068,7 +1068,7 @@ function compile_lambda_expression(exp, target, linkage) {
 	  <SCHEME><SCHEMEINLINE>append-instruction-sequences</SCHEMEINLINE>
 	  </SCHEME>
 	  <JAVASCRIPT>
-	    <JAVASCRIPTINLINE>append_instruction_sequences</JAVASCRIPTINLINE>
+	    <JAVASCRIPTINLINE>append_@instruction_@sequences</JAVASCRIPTINLINE>
 	  </JAVASCRIPT>
 	</SPLITINLINE>
 	to append the
@@ -1203,7 +1203,7 @@ function compile_lambda_body(exp, fun_entry) {
 	<JAVASCRIPT>
 	  <TEXT>
 	    To ensure that every function ends by executing a return statement,
-	    <JAVASCRIPTINLINE>compile_lambda_body</JAVASCRIPTINLINE>
+	    <JAVASCRIPTINLINE>compile_@lambda_@body</JAVASCRIPTINLINE>
 	    appends a return statement whose return expression is the literal
 	    <JAVASCRIPTINLINE>undefined</JAVASCRIPTINLINE>
 	    to the lambda body. To do so, it uses the function <JAVASCRIPTINLINE>append_return_undefined</JAVASCRIPTINLINE>,

--- a/xml/chapter5/section5/subsection3.xml
+++ b/xml/chapter5/section5/subsection3.xml
@@ -634,7 +634,7 @@ function compile_function_call(target, linkage) {
     and false branches in
     <SPLITINLINE>
       <SCHEME><SCHEMEINLINE>compile-if</SCHEMEINLINE>,</SCHEME>
-      <JAVASCRIPT><JAVASCRIPTINLINE>compile_conditional</JAVASCRIPTINLINE>,</JAVASCRIPT>
+      <JAVASCRIPT><JAVASCRIPTINLINE>compile_@conditional</JAVASCRIPTINLINE>,</JAVASCRIPT>
     </SPLITINLINE>
     are appended using
     <SPLITINLINE>

--- a/xml/chapter5/section5/subsection6.xml
+++ b/xml/chapter5/section5/subsection6.xml
@@ -486,7 +486,7 @@
     <SPLITINLINE>
       <SCHEME><SCHEMEINLINE>Lexical-address-lookup</SCHEMEINLINE></SCHEME>
       <JAVASCRIPT>The function
-      <JAVASCRIPTINLINE>lexical_address_lookup</JAVASCRIPTINLINE>
+      <JAVASCRIPTINLINE>lexical_@address_@lookup</JAVASCRIPTINLINE>
       </JAVASCRIPT>
     </SPLITINLINE>
     should signal an error if the value

--- a/xml/chapter5/section5/subsection7.xml
+++ b/xml/chapter5/section5/subsection7.xml
@@ -1406,7 +1406,7 @@ $\texttt{ }\texttt{ }$assign("compapp", label("compound_apply")),
 	<SCHEMEINLINE>compile-and-go</SCHEMEINLINE>
       </SCHEME>
       <JAVASCRIPT>
-	<JAVASCRIPTINLINE>compile_and_go</JAVASCRIPTINLINE>
+	<JAVASCRIPTINLINE>compile_@and_@go</JAVASCRIPTINLINE>
       </JAVASCRIPT>
     </SPLITINLINE>
     to compile the


### PR DESCRIPTION
Adding an `@` in JAVASCRIPTINLINE tag allows that place to have a line break. Should only be visible in PDF. 