### PR TITLE
JSON: Fix links

### DIFF
--- a/javascript/processingFunctions/processReferenceJson.js
+++ b/javascript/processingFunctions/processReferenceJson.js
@@ -128,7 +128,7 @@ export const setupReferencesJson = (node, filename) => {
   }
 };
 
-export const processReferenceJson = (node, obj, chapterIndex) => {
+export const processReferenceJson = (node, obj) => {
   const referenceName = node.getAttribute("NAME");
   if (!referenceStore[referenceName]) {
     missingReferenceWarning(referenceName);
@@ -137,15 +137,8 @@ export const processReferenceJson = (node, obj, chapterIndex) => {
 
   const href = referenceStore[referenceName].href;
   const displayName = referenceStore[referenceName].displayName;
-  const ref_type = referenceName.split(":")[0];
 
-  if (ref_type == "foot") {
-    obj["tag"] = "FOOTNOTE_REF";
-    obj["id"] = `${chapterIndex}-foot-link-${displayName}`;
-  } else {
-    obj["tag"] = "REF";
-  }
-
+  obj["tag"] = "REF";
   obj["body"] = displayName;
   obj["href"] = href;
 };


### PR DESCRIPTION
Previously, some links were incorrectly displayed as superscript.

<img width="812" alt="Screenshot 2021-07-14 at 3 29 15 AM" src="https://user-images.githubusercontent.com/60355570/125513380-517c4316-773a-4200-9b2a-1631edbf0975.png">

This PR fixes this issue.

<img width="813" alt="Screenshot 2021-07-14 at 3 29 59 AM" src="https://user-images.githubusercontent.com/60355570/125513477-631f8ce8-26ec-4a41-ae71-d8ce0ef64bfe.png">
