### PR TITLE
Fixing code spaces

### DIFF
--- a/javascript/processingFunctions/processSnippetPdf.js
+++ b/javascript/processingFunctions/processSnippetPdf.js
@@ -248,7 +248,7 @@ export const processSnippetPdf = (node, writeTo) => {
       writeTo.push(
         codeArr
           .join("")
-          .replace(/}\nfunction/g, "}\n" + separator + "function")
+          .replace(/^}\nfunction/g, "}\n" + separator + "function")
           .replace(/\n@xxx\n/g, separator)
           .replace(/\n@yyy\n/g, separator) // smallskip should allow page breaks
           .trim()

--- a/javascript/processingFunctions/processSnippetPdf.js
+++ b/javascript/processingFunctions/processSnippetPdf.js
@@ -248,7 +248,7 @@ export const processSnippetPdf = (node, writeTo) => {
       writeTo.push(
         codeArr
           .join("")
-          .replace(/^}\nfunction/g, "}\n" + separator + "function")
+          .replace(/\n}\nfunction/g, "\n}\n" + separator + "function")
           .replace(/\n@xxx\n/g, separator)
           .replace(/\n@yyy\n/g, separator) // smallskip should allow page breaks
           .trim()
@@ -397,7 +397,7 @@ export const processSnippetPdf = (node, writeTo) => {
       writeTo.push(
         lines
           .join("\n")
-          .replace(/}\nfunction/g, "}\n" + separator + "function")
+          .replace(/\n}\nfunction/g, "\n}\n" + separator + "function")
           .replace(/\n@yyy\n/g, separator2)
           .replace(/\n@xxx\n/g, separator)
           .trim()

--- a/xml/chapter1/section1/subsection6.xml
+++ b/xml/chapter1/section1/subsection6.xml
@@ -1052,7 +1052,9 @@ f(4, 7, 2);
           <EXAMPLE>plusminusexample</EXAMPLE>
           <JAVASCRIPT>
 function plus(a, b) { return a + b; }
+<SHORT_SPACE/>
 function minus(a, b) { return a - b; }
+<SHORT_SPACE/>
 function a_plus_abs_b(a, b) {
     return (b >= 0 ? plus : minus)(a, b);
 }

--- a/xml/chapter2/section4/subsection3.xml
+++ b/xml/chapter2/section4/subsection3.xml
@@ -707,8 +707,11 @@ function apply_generic(op, args) {
       </SCHEME>
       <JAVASCRIPT>
 function real_part(z) { return apply_generic("real_part", list(z)); }
+<SHORT_SPACE/>
 function imag_part(z) { return apply_generic("imag_part", list(z)); }
+<SHORT_SPACE/>
 function magnitude(z) { return apply_generic("magnitude", list(z)); }
+<SHORT_SPACE/>
 function angle(z)     { return apply_generic("angle", list(z));     }
       </JAVASCRIPT>
     </SNIPPET>

--- a/xml/chapter2/section5/subsection1.xml
+++ b/xml/chapter2/section5/subsection1.xml
@@ -1,3 +1,4 @@
+
 <SUBSECTION>
   <NAME>
     Generic Arithmetic Operations
@@ -58,8 +59,11 @@
       </SCHEME>
       <JAVASCRIPT>
 function add(x, y) { return apply_generic("add", list(x, y)); }
+<SHORT_SPACE/>
 function sub(x, y) { return apply_generic("sub", list(x, y)); }
+<SHORT_SPACE/>
 function mul(x, y) { return apply_generic("mul", list(x, y)); }
+<SHORT_SPACE/>
 function div(x, y) { return apply_generic("div", list(x, y)); }
       </JAVASCRIPT>
     </SNIPPET>

--- a/xml/chapter2/section5/subsection3.xml
+++ b/xml/chapter2/section5/subsection3.xml
@@ -792,13 +792,19 @@ function adjoin_term(term, term_list) {
            ? term_list
            : pair(term, term_list);
 }
+<SHORT_SPACE/>
 const the_empty_termlist = null;
+<SHORT_SPACE/>
 function first_term(term_list) { return head(term_list); }
+<SHORT_SPACE/>
 function rest_terms(term_list) { return tail(term_list); }
+<SHORT_SPACE/>
 function is_empty_termlist(term_list) { return is_null(term_list); }
 
 function make_term(order, coeff) { return list(order, coeff); }
+<SHORT_SPACE/>
 function order(term) { return head(term); }
+<SHORT_SPACE/>
 function coeff(term) { return head(tail(term)); }
       </JAVASCRIPT>
     </SNIPPET>

--- a/xml/chapter3/section3/subsection1.xml
+++ b/xml/chapter3/section3/subsection1.xml
@@ -1574,7 +1574,9 @@ function pair(x, y) {
     }
     return dispatch;	      
 }
+<SHORT_SPACE/>
 function head(z) { return z("head"); }
+<SHORT_SPACE/>
 function tail(z) { return z("tail"); }
       </JAVASCRIPT>
     </SNIPPET>
@@ -1658,6 +1660,7 @@ function pair(x, y) {
 }
 <SHORT_SPACE_AND_ALLOW_BREAK/>
 function head(z) { return z("head"); }
+<SHORT_SPACE/>
 function tail(z) { return z("tail"); }
 
 function set_head(z, new_value) {

--- a/xml/chapter3/section3/subsection4.xml
+++ b/xml/chapter3/section3/subsection4.xml
@@ -1642,7 +1642,9 @@ function accept_action_function(fun) {
 function make_time_segment(time, queue) {
     return pair(time, queue);
 }
+<SHORT_SPACE/>
 function segment_time(s) { return head(s); }
+<SHORT_SPACE/>
 function segment_queue(s) { return tail(s); }
       </JAVASCRIPT>
     </SNIPPET>
@@ -1707,16 +1709,19 @@ function segment_queue(s) { return tail(s); }
 function make_agenda() { return list(0); }
 
 function current_time(agenda) { return head(agenda); }
+<SHORT_SPACE/>
 function set_current_time(agenda, time) {
     set_head(agenda, time);
 }
 
 function segments(agenda) { return tail(agenda); }
+<SHORT_SPACE/>
 function set_segments(agenda, segs) {
     set_tail(agenda, segs);
 }
 
 function first_segment(agenda) { return head(segments(agenda)); }
+<SHORT_SPACE/>
 function rest_segments(agenda) { return tail(segments(agenda)); }
       </JAVASCRIPT>
     </SNIPPET>

--- a/xml/chapter4/section1/subsection3.xml
+++ b/xml/chapter4/section1/subsection3.xml
@@ -62,6 +62,7 @@
 	  <NAME>true_2</NAME>
 	  <JAVASCRIPT>
 function is_truthy(x) { return ! is_falsy(x); }
+<SHORT_SPACE/>
 function is_falsy(x) {
     return (is_boolean(x) &amp;&amp; !x )                  ||
            (is_number(x) &amp;&amp; (x === 0 || x !== x )) ||

--- a/xml/chapter4/section4/subsection4.xml
+++ b/xml/chapter4/section4/subsection4.xml
@@ -3401,11 +3401,15 @@ function assertion_body(exp) {
 	<EXAMPLE>append_to_form_example_5</EXAMPLE>
 	<JAVASCRIPT>
 function is_empty_conjunction(exps) { return is_null(exps); }
+<SHORT_SPACE/>
 function first_conjunct(exps) { return head(exps); }
+<SHORT_SPACE/>
 function rest_conjuncts(exps) { return tail(exps); }
 
 function is_empty_disjunction(exps) { return is_null(exps); }
+<SHORT_SPACE/>
 function first_disjunct(exps) { return head(exps); }
+<SHORT_SPACE/>
 function rest_disjuncts(exps) { return tail(exps); }
 
 function negated_query(exps) { return head(exps); }

--- a/xml/chapter5/section2/subsection3.xml
+++ b/xml/chapter5/section2/subsection3.xml
@@ -562,6 +562,7 @@ function make_test_ef(inst, machine, labels, operations, flag, pc) {
           <EXAMPLE>gcd_machine_complete_example</EXAMPLE>
           <JAVASCRIPT>
 function test(condition) { return list("test", condition); }
+<SHORT_SPACE/>
 function test_condition(test_instruction) {
     return head(tail(test_instruction)); 
 }
@@ -652,6 +653,7 @@ function make_branch_ef(inst, machine, labels, flag, pc) {
           <EXAMPLE>gcd_machine_complete_example</EXAMPLE>
           <JAVASCRIPT>
 function branch(label) { return list("branch", label); }
+<SHORT_SPACE/>
 function branch_dest(branch_instruction) {
     return head(tail(branch_instruction)); 
 }
@@ -728,6 +730,7 @@ function make_go_to_ef(inst, machine, labels, pc) {
           <EXAMPLE>go_to_go_to_dest</EXAMPLE>
           <JAVASCRIPT>
 function go_to(label) { return list("go_to", label); }
+<SHORT_SPACE/>
 function go_to_dest(go_to_instruction) { 
     return head(tail(go_to_instruction)); 
 }
@@ -809,7 +812,9 @@ function make_restore_ef(inst, machine, stack, pc) {
 	  <EXAMPLE>gcd_machine_complete_example</EXAMPLE>
 	  <JAVASCRIPT>
 function save(reg) { return list("save", reg); }
+<SHORT_SPACE/>
 function restore(reg) { return list("restore", reg); }
+<SHORT_SPACE/>
 function stack_inst_reg_name(stack_instruction) {
     return head(tail(stack_instruction));
 }
@@ -890,6 +895,7 @@ function make_perform_ef(inst, machine, labels, operations, pc) {
           <EXAMPLE>perform_perform_action</EXAMPLE>
           <JAVASCRIPT>
 function perform(action) { return list("perform", action); }
+<SHORT_SPACE/>
 function perform_action(perform_instruction) {
     return head(tail(perform_instruction));
 }
@@ -1035,17 +1041,23 @@ function make_primitive_exp_ef(exp, machine, labels) {
 	  <EXAMPLE>gcd_machine_complete_example</EXAMPLE>
 	  <JAVASCRIPT>
 function reg(name) { return list("reg", name); }
+<SHORT_SPACE/>
 function is_register_exp(exp) { return is_tagged_list(exp, "reg"); }
+<SHORT_SPACE/>
 function register_exp_reg(exp) { return head(tail(exp)); }
 
 function constant(value) { return list("constant", value); }
+<SHORT_SPACE/>
 function is_constant_exp(exp) {
     return is_tagged_list(exp, "constant");
 }
+<SHORT_SPACE/>
 function constant_exp_value(exp) { return head(tail(exp)); }
 
 function label(name) { return list("label", name); }
+<SHORT_SPACE/>
 function is_label_exp(exp) { return is_tagged_list(exp, "label"); }
+<SHORT_SPACE/>
 function label_exp_label(exp) { return head(tail(exp)); }
 	  </JAVASCRIPT>
 	</SNIPPET>
@@ -1149,10 +1161,13 @@ function make_operation_exp_ef(exp, machine, labels, operations) {
 	  <EXAMPLE>gcd_machine_complete_example</EXAMPLE>
 	  <JAVASCRIPT>
 function op(name) { return list("op", name); }
+<SHORT_SPACE/>
 function is_operation_exp(exp) {
     return is_pair(exp) &amp;&amp; is_tagged_list(head(exp), "op");
 }
+<SHORT_SPACE/>
 function operation_exp_op(op_exp) { return head(tail(head(op_exp))); }
+<SHORT_SPACE/>
 function operation_exp_operands(op_exp) { return tail(op_exp); }
 	  </JAVASCRIPT>
 	</SNIPPET>


### PR DESCRIPTION
There was a bug in the script for inserting spaces between function declarations. It inserted space before
any (non-indented) function start. This caused the bad spacing you pointed out this morning. 

I have fixed this by making the rules stricter for when we insert space: We insert space before a (non-indented) function if
the previous line was a lone "}". 

To avoid stepping back on lots of inter-function spaces that we have agreed that we like, I've manually inserted `<SHORT_SPACE/>` tags in places in the book that changed as a consequence. There were about 40 places. 

Before we present this to Julie, can you take a look and see that this makes sense to you? 