### PR TITLE
WEB: Fix typo in chapter 1.1.1

### DIFF
--- a/xml/chapter1/section1/subsection1.xml
+++ b/xml/chapter1/section1/subsection1.xml
@@ -39,7 +39,7 @@
 	  displayed, which can <EM>evaluate</EM> the
 	  statement and display the resulting value.
 	  By the way, the program that makes the mouse click
-	  on a JavaScript statement display the interpreter is itself
+	  on a JavaScript statement to display the interpreter is itself
 	  written in JavaScript; it is called the <EM>script</EM> for
 	  the mouse click. Such scripts were a central objective in
 	  the original design of JavaScript.


### PR DESCRIPTION
Possible typo in chapter 1.1.1, though i'm a little unsure about this. The text is in a web_only tag so no changes to pdf edition.

See changes for typo. 