### PR TITLE
Replace occurrences of "@xxx" and "@yyy" in web version

### DIFF
--- a/javascript/processingFunctions/processSnippetJson.js
+++ b/javascript/processingFunctions/processSnippetJson.js
@@ -28,7 +28,11 @@ export const setupSnippetsJson = node => {
       }
       const codeArr = [];
       recursiveProcessPureText(jsRunSnippet.firstChild, codeArr);
-      const codeStr = codeArr.join("").trim();
+      const codeStr = codeArr
+        .join("")
+        .replace(/@xxx\n/g, "")
+        .replace(/@yyy\n/g, "")
+        .trim();
       const requirements = snippet.getElementsByTagName("REQUIRES");
       const requireNames = [];
       for (let i = 0; requirements[i]; i++) {


### PR DESCRIPTION
Fixes #591,

Replaced occurrences of "@xxx" and "@yyy" with an empty string. Examples in 5.2 work now (see screenshot). 

<img width="1295" alt="Screenshot 2021-08-04 at 9 07 50 AM" src="https://user-images.githubusercontent.com/60355570/128105751-20ad9fb2-c66a-4e9f-baf6-1f5f7a025897.png">
