### PR TITLE
Remove remaining occurrences of "@xxx" from non-pdf versions

### DIFF
--- a/javascript/parseXmlLatex.js
+++ b/javascript/parseXmlLatex.js
@@ -518,7 +518,7 @@ const processTextFunctionsDefaultLatex = {
   LATEX: (node, writeTo) =>
     processTextFunctionsLatex["LATEXINLINE"](node, writeTo),
   LATEXINLINE: (node, writeTo) => {
-    recursiveProcessPureText(node.firstChild, writeTo);
+    recursiveProcessPureText(node.firstChild, writeTo, { type: parseType });
   },
 
   LaTeX: (node, writeTo) => {
@@ -623,7 +623,7 @@ const processTextFunctionsDefaultLatex = {
   JAVASCRIPTINLINE: (node, writeTo) => {
     if (ancestorHasTag(node, "METAPHRASE")) {
       writeTo.push("}$");
-      recursiveProcessPureText(node.firstChild, writeTo);
+      recursiveProcessPureText(node.firstChild, writeTo, { type: parseType });
       writeTo.push("$\\mathit{");
     } else {
       if (node.getAttribute("break")) {
@@ -742,7 +742,10 @@ export const processTextLatex = (node, writeTo) => {
     processTextFunctionsLatex[name](node, writeTo);
     return true;
   } else {
-    if (replaceTagWithSymbol(node, writeTo) || tagsToRemove.has(name)) {
+    if (
+      replaceTagWithSymbol(node, writeTo, parseType) ||
+      tagsToRemove.has(name)
+    ) {
       return true;
     } else if (ignoreTags.has(name)) {
       recursiveProcessTextLatex(node.firstChild, writeTo);

--- a/javascript/processingFunctions/processSnippetEpub.js
+++ b/javascript/processingFunctions/processSnippetEpub.js
@@ -31,9 +31,7 @@ export const setupSnippetsEpub = node => {
       recursiveProcessPureText(jsRunSnippet.firstChild, codeArr, {
         type: "epub"
       });
-      const codeStr = codeArr
-        .join("")
-        .trim();
+      const codeStr = codeArr.join("").trim();
 
       const requirements = snippet.getElementsByTagName("REQUIRES");
       const requireNames = [];
@@ -74,9 +72,7 @@ export const processSnippetEpub = (node, writeTo) => {
 
     const codeArr = [];
     recursiveProcessPureText(jsSnippet.firstChild, codeArr);
-    const codeStr = codeArr
-      .join("")
-      .trim();
+    const codeStr = codeArr.join("").trim();
 
     const codeArr_run = [];
     recursiveProcessPureText(jsRunSnippet.firstChild, codeArr_run);

--- a/javascript/processingFunctions/processSnippetEpub.js
+++ b/javascript/processingFunctions/processSnippetEpub.js
@@ -28,11 +28,11 @@ export const setupSnippetsEpub = node => {
         return;
       }
       const codeArr = [];
-      recursiveProcessPureText(jsRunSnippet.firstChild, codeArr);
+      recursiveProcessPureText(jsRunSnippet.firstChild, codeArr, {
+        type: "epub"
+      });
       const codeStr = codeArr
         .join("")
-        .replace(/@xxx\n/g, "")
-        .replace(/@yyy\n/g, "")
         .trim();
 
       const requirements = snippet.getElementsByTagName("REQUIRES");
@@ -76,8 +76,6 @@ export const processSnippetEpub = (node, writeTo) => {
     recursiveProcessPureText(jsSnippet.firstChild, codeArr);
     const codeStr = codeArr
       .join("")
-      .replace(/@xxx\n/g, "")
-      .replace(/@yyy\n/g, "")
       .trim();
 
     const codeArr_run = [];

--- a/javascript/processingFunctions/processSnippetHtml.js
+++ b/javascript/processingFunctions/processSnippetHtml.js
@@ -29,9 +29,7 @@ export const setupSnippetsHtml = node => {
       }
       const codeArr = [];
       recursiveProcessPureText(jsRunSnippet.firstChild, codeArr);
-      const codeStr = codeArr
-        .join("")
-        .trim();
+      const codeStr = codeArr.join("").trim();
       const requirements = snippet.getElementsByTagName("REQUIRES");
       const requireNames = [];
       for (let i = 0; requirements[i]; i++) {
@@ -91,16 +89,12 @@ export const processSnippetHtml = (node, writeTo, split) => {
 
     const codeArr = [];
     if (jsSnippet) recursiveProcessPureText(jsSnippet.firstChild, codeArr);
-    const codeStr = codeArr
-      .join("")
-      .trim();
+    const codeStr = codeArr.join("").trim();
 
     const codeArr_run = [];
     if (jsRunSnippet)
       recursiveProcessPureText(jsRunSnippet.firstChild, codeArr_run);
-    const codeStr_run = codeArr_run
-      .join("")
-      .trim();
+    const codeStr_run = codeArr_run.join("").trim();
 
     // Do warning for very long lines if no latex
     if (node.getAttribute("LATEX") !== "yes") {

--- a/javascript/processingFunctions/processSnippetHtml.js
+++ b/javascript/processingFunctions/processSnippetHtml.js
@@ -31,8 +31,8 @@ export const setupSnippetsHtml = node => {
       recursiveProcessPureText(jsRunSnippet.firstChild, codeArr);
       const codeStr = codeArr
         .join("")
-        .replace(/@xxx\n/g, "")
-        .replace(/@yyy\n/g, "")
+        .replace(/@xxx[\n\t]*/g, "\n")
+        .replace(/@yyy[\n\t]*/g, "\n")
         .trim();
       const requirements = snippet.getElementsByTagName("REQUIRES");
       const requireNames = [];
@@ -95,14 +95,18 @@ export const processSnippetHtml = (node, writeTo, split) => {
     if (jsSnippet) recursiveProcessPureText(jsSnippet.firstChild, codeArr);
     const codeStr = codeArr
       .join("")
-      .replace(/@xxx\n/g, "")
-      .replace(/@yyy\n/g, "")
+      .replace(/@xxx[\n\t]*/g, "\n")
+      .replace(/@yyy[\n\t]*/g, "\n")
       .trim();
 
     const codeArr_run = [];
     if (jsRunSnippet)
       recursiveProcessPureText(jsRunSnippet.firstChild, codeArr_run);
-    const codeStr_run = codeArr_run.join("").trim();
+    const codeStr_run = codeArr_run
+      .join("")
+      .replace(/@xxx[\n\t]*/g, "\n")
+      .replace(/@yyy[\n\t]*/g, "\n")
+      .trim();
 
     // Do warning for very long lines if no latex
     if (node.getAttribute("LATEX") !== "yes") {

--- a/javascript/processingFunctions/processSnippetHtml.js
+++ b/javascript/processingFunctions/processSnippetHtml.js
@@ -31,8 +31,6 @@ export const setupSnippetsHtml = node => {
       recursiveProcessPureText(jsRunSnippet.firstChild, codeArr);
       const codeStr = codeArr
         .join("")
-        .replace(/@xxx[\n\t]*/g, "\n")
-        .replace(/@yyy[\n\t]*/g, "\n")
         .trim();
       const requirements = snippet.getElementsByTagName("REQUIRES");
       const requireNames = [];
@@ -104,8 +102,6 @@ export const processSnippetHtml = (node, writeTo, split) => {
       recursiveProcessPureText(jsRunSnippet.firstChild, codeArr_run);
     const codeStr_run = codeArr_run
       .join("")
-      .replace(/@xxx[\n\t]*/g, "\n")
-      .replace(/@yyy[\n\t]*/g, "\n")
       .trim();
 
     // Do warning for very long lines if no latex

--- a/javascript/processingFunctions/processSnippetHtml.js
+++ b/javascript/processingFunctions/processSnippetHtml.js
@@ -93,8 +93,6 @@ export const processSnippetHtml = (node, writeTo, split) => {
     if (jsSnippet) recursiveProcessPureText(jsSnippet.firstChild, codeArr);
     const codeStr = codeArr
       .join("")
-      .replace(/@xxx[\n\t]*/g, "\n")
-      .replace(/@yyy[\n\t]*/g, "\n")
       .trim();
 
     const codeArr_run = [];

--- a/javascript/processingFunctions/processSnippetJs.js
+++ b/javascript/processingFunctions/processSnippetJs.js
@@ -34,8 +34,8 @@ export const setupSnippetsJs = node => {
 
       const codeStr = codeArr
         .join("")
-        .replace(/@xxx\n/g, "")
-        .replace(/@yyy\n/g, "")
+        .replace(/@xxx[\n\t]*/g, "\n")
+        .replace(/@yyy[\n\t]*/g, "\n")
         .trim();
 
       const requirements = snippet.getElementsByTagName("REQUIRES");
@@ -89,15 +89,14 @@ export const processSnippetJs = (node, writeTo, fileFormat) => {
     }
     const codeArr = [];
     recursiveProcessPureText(jsSnippet.firstChild, codeArr);
-    const codeStr = codeArr
-      .join("")
-      .replace(/@xxx\n/g, "")
-      .replace(/@yyy\n/g, "")
-      .trim();
 
     const codeArr_run = [];
     recursiveProcessPureText(jsRunSnippet.firstChild, codeArr_run);
-    const codeStr_run = codeArr_run.join("").trim();
+    const codeStr_run = codeArr_run
+      .join("")
+      .replace(/@xxx[\n\t]*/g, "\n")
+      .replace(/@yyy[\n\t]*/g, "\n")
+      .trim();
 
     let reqStr = "";
     let reqArr = [];

--- a/javascript/processingFunctions/processSnippetJs.js
+++ b/javascript/processingFunctions/processSnippetJs.js
@@ -87,8 +87,6 @@ export const processSnippetJs = (node, writeTo, fileFormat) => {
         jsRunSnippet = jsSnippet;
       }
     }
-    const codeArr = [];
-    recursiveProcessPureText(jsSnippet.firstChild, codeArr);
 
     const codeArr_run = [];
     recursiveProcessPureText(jsRunSnippet.firstChild, codeArr_run);

--- a/javascript/processingFunctions/processSnippetJs.js
+++ b/javascript/processingFunctions/processSnippetJs.js
@@ -34,8 +34,6 @@ export const setupSnippetsJs = node => {
 
       const codeStr = codeArr
         .join("")
-        .replace(/@xxx[\n\t]*/g, "\n")
-        .replace(/@yyy[\n\t]*/g, "\n")
         .trim();
 
       const requirements = snippet.getElementsByTagName("REQUIRES");
@@ -92,8 +90,6 @@ export const processSnippetJs = (node, writeTo, fileFormat) => {
     recursiveProcessPureText(jsRunSnippet.firstChild, codeArr_run);
     const codeStr_run = codeArr_run
       .join("")
-      .replace(/@xxx[\n\t]*/g, "\n")
-      .replace(/@yyy[\n\t]*/g, "\n")
       .trim();
 
     let reqStr = "";

--- a/javascript/processingFunctions/processSnippetJs.js
+++ b/javascript/processingFunctions/processSnippetJs.js
@@ -32,9 +32,7 @@ export const setupSnippetsJs = node => {
       const codeArr = [];
       recursiveProcessPureText(jsRunSnippet.firstChild, codeArr);
 
-      const codeStr = codeArr
-        .join("")
-        .trim();
+      const codeStr = codeArr.join("").trim();
 
       const requirements = snippet.getElementsByTagName("REQUIRES");
       const requireNames = [];
@@ -88,9 +86,7 @@ export const processSnippetJs = (node, writeTo, fileFormat) => {
 
     const codeArr_run = [];
     recursiveProcessPureText(jsRunSnippet.firstChild, codeArr_run);
-    const codeStr_run = codeArr_run
-      .join("")
-      .trim();
+    const codeStr_run = codeArr_run.join("").trim();
 
     let reqStr = "";
     let reqArr = [];

--- a/javascript/processingFunctions/processSnippetJson.js
+++ b/javascript/processingFunctions/processSnippetJson.js
@@ -86,6 +86,7 @@ export const recursivelyProcessTextSnippetJson = (node, writeTo) => {
   } else if (name === "#comment" || name === "ALLOW_BREAK") {
     return;
   } else if (name === "SHORT_SPACE" || name === "SHORT_SPACE_AND_ALLOW_BREAK") {
+    writeTo.push("\n");
   } else {
     console.log(`processSnippetJson: UNRECOGNISED TAG ${name}\n\n`);
   }

--- a/javascript/processingFunctions/processSnippetJson.js
+++ b/javascript/processingFunctions/processSnippetJson.js
@@ -28,9 +28,7 @@ export const setupSnippetsJson = node => {
       }
       const codeArr = [];
       recursiveProcessPureText(jsRunSnippet.firstChild, codeArr);
-      const codeStr = codeArr
-        .join("")
-        .trim();
+      const codeStr = codeArr.join("").trim();
 
       const requirements = snippet.getElementsByTagName("REQUIRES");
       const requireNames = [];
@@ -117,9 +115,7 @@ export const processSnippetJson = (node, snippet) => {
 
     const codeArr = [];
     recursiveProcessPureText(jsSnippet.firstChild, codeArr);
-    let codeStr = codeArr
-      .join("")
-      .trim();
+    let codeStr = codeArr.join("").trim();
 
     // Remove newline from beginning and end
     codeStr = codeStr.replace(/^[\r\n]+/g, "");
@@ -129,9 +125,7 @@ export const processSnippetJson = (node, snippet) => {
     if (jsRunSnippet) {
       recursiveProcessPureText(jsRunSnippet.firstChild, codeArr_run);
     }
-    const codeStr_run = codeArr_run
-      .join("")
-      .trim();
+    const codeStr_run = codeArr_run.join("").trim();
 
     if (node.getAttribute("EVAL") === "no") {
       addToSnippet("body", codeStr, snippet);

--- a/javascript/processingFunctions/processSnippetJson.js
+++ b/javascript/processingFunctions/processSnippetJson.js
@@ -30,9 +30,10 @@ export const setupSnippetsJson = node => {
       recursiveProcessPureText(jsRunSnippet.firstChild, codeArr);
       const codeStr = codeArr
         .join("")
-        .replace(/@xxx\n/g, "")
-        .replace(/@yyy\n/g, "")
+        .replace(/@xxx[\n\t]*/g, "\n")
+        .replace(/@yyy[\n\t]*/g, "\n")
         .trim();
+
       const requirements = snippet.getElementsByTagName("REQUIRES");
       const requireNames = [];
       for (let i = 0; requirements[i]; i++) {
@@ -84,6 +85,7 @@ export const recursivelyProcessTextSnippetJson = (node, writeTo) => {
     recursivelyProcessTextSnippetJson(node.firstChild, writeTo);
   } else if (name === "#comment" || name === "ALLOW_BREAK") {
     return;
+  } else if (name === "SHORT_SPACE" || name === "SHORT_SPACE_AND_ALLOW_BREAK") {
   } else {
     console.log(`processSnippetJson: UNRECOGNISED TAG ${name}\n\n`);
   }
@@ -116,7 +118,12 @@ export const processSnippetJson = (node, snippet) => {
 
     const codeArr = [];
     recursiveProcessPureText(jsSnippet.firstChild, codeArr);
-    let codeStr = codeArr.join("");
+    let codeStr = codeArr
+      .join("")
+      .replace(/@xxx[\n\t]*/g, "\n")
+      .replace(/@yyy[\n\t]*/g, "\n")
+      .trim();
+
     // Remove newline from beginning and end
     codeStr = codeStr.replace(/^[\r\n]+/g, "");
     codeStr = codeStr.replace(/[\r\n\s]+$/g, "");
@@ -125,7 +132,11 @@ export const processSnippetJson = (node, snippet) => {
     if (jsRunSnippet) {
       recursiveProcessPureText(jsRunSnippet.firstChild, codeArr_run);
     }
-    const codeStr_run = codeArr_run.join("").trim();
+    const codeStr_run = codeArr_run
+      .join("")
+      .replace(/@xxx[\n\t]*/g, "\n")
+      .replace(/@yyy[\n\t]*/g, "\n")
+      .trim();
 
     if (node.getAttribute("EVAL") === "no") {
       addToSnippet("body", codeStr, snippet);

--- a/javascript/processingFunctions/processSnippetJson.js
+++ b/javascript/processingFunctions/processSnippetJson.js
@@ -30,8 +30,6 @@ export const setupSnippetsJson = node => {
       recursiveProcessPureText(jsRunSnippet.firstChild, codeArr);
       const codeStr = codeArr
         .join("")
-        .replace(/@xxx[\n\t]*/g, "\n")
-        .replace(/@yyy[\n\t]*/g, "\n")
         .trim();
 
       const requirements = snippet.getElementsByTagName("REQUIRES");
@@ -121,8 +119,6 @@ export const processSnippetJson = (node, snippet) => {
     recursiveProcessPureText(jsSnippet.firstChild, codeArr);
     let codeStr = codeArr
       .join("")
-      .replace(/@xxx[\n\t]*/g, "\n")
-      .replace(/@yyy[\n\t]*/g, "\n")
       .trim();
 
     // Remove newline from beginning and end
@@ -135,8 +131,6 @@ export const processSnippetJson = (node, snippet) => {
     }
     const codeStr_run = codeArr_run
       .join("")
-      .replace(/@xxx[\n\t]*/g, "\n")
-      .replace(/@yyy[\n\t]*/g, "\n")
       .trim();
 
     if (node.getAttribute("EVAL") === "no") {

--- a/javascript/processingFunctions/processSnippetPdf.js
+++ b/javascript/processingFunctions/processSnippetPdf.js
@@ -29,7 +29,9 @@ export const setupSnippetsPdf = node => {
         return;
       }
       const codeArr = [];
-      recursiveProcessPureText(jsRunSnippet.firstChild, codeArr);
+      recursiveProcessPureText(jsRunSnippet.firstChild, codeArr, {
+        type: "pdf"
+      });
       const codeStr = codeArr.join("").trim();
 
       const requirements = snippet.getElementsByTagName("REQUIRES");
@@ -207,7 +209,9 @@ export const processSnippetPdf = (node, writeTo) => {
       .trim();
 
     const codeArr_run = [];
-    recursiveProcessPureText(jsRunSnippet.firstChild, codeArr_run);
+    recursiveProcessPureText(jsRunSnippet.firstChild, codeArr_run, {
+      type: "pdf"
+    });
     const codeStr_run = codeArr_run.join("").trim();
 
     // Do warning for very long lines if no latex

--- a/javascript/processingFunctions/recursiveProcessPureText.js
+++ b/javascript/processingFunctions/recursiveProcessPureText.js
@@ -1,6 +1,6 @@
 import replaceTagWithSymbol from "./replaceTagWithSymbol";
 
-const recursiveProcessPureTextDefault = { removeNewline: false };
+const recursiveProcessPureTextDefault = { removeNewline: false, type: false };
 
 const recursiveProcessPureText = (
   node,
@@ -8,7 +8,8 @@ const recursiveProcessPureText = (
   options = recursiveProcessPureTextDefault
 ) => {
   if (!node) return;
-  if (!replaceTagWithSymbol(node, writeTo) && node.nodeName === "#text") {
+
+  if (!replaceTagWithSymbol(node, writeTo, options.type) && node.nodeName === "#text") {
     let value = node.nodeValue;
     if (options.removeNewline == "beginning&end") {
       value = value.replace(/^[\r\n]+/g, "");

--- a/javascript/processingFunctions/recursiveProcessPureText.js
+++ b/javascript/processingFunctions/recursiveProcessPureText.js
@@ -9,7 +9,10 @@ const recursiveProcessPureText = (
 ) => {
   if (!node) return;
 
-  if (!replaceTagWithSymbol(node, writeTo, options.type) && node.nodeName === "#text") {
+  if (
+    !replaceTagWithSymbol(node, writeTo, options.type) &&
+    node.nodeName === "#text"
+  ) {
     let value = node.nodeValue;
     if (options.removeNewline == "beginning&end") {
       value = value.replace(/^[\r\n]+/g, "");

--- a/javascript/processingFunctions/replaceTagWithSymbol.js
+++ b/javascript/processingFunctions/replaceTagWithSymbol.js
@@ -1,4 +1,4 @@
-const tagsToReplace = {
+const tagsToReplaceDefault = {
   APOS: "'",
   WJ: "&#8288;",
   AACUTE_LOWER: "á",
@@ -22,8 +22,8 @@ const tagsToReplace = {
   SHARP: "\\#",
   SECT: "§",
 
-  SHORT_SPACE: "@xxx", // will be replaced in processSnippet depending on rendering target (PDF, HTML, etc.)
-  SHORT_SPACE_AND_ALLOW_BREAK: "@yyy", // will be replaced in processSnippet depending on rendering target (PDF, HTML, etc.)
+  SHORT_SPACE: "",
+  SHORT_SPACE_AND_ALLOW_BREAK: "",
 
   EMDASH: "—",
   ENDASH: "–",
@@ -34,8 +34,23 @@ const tagsToReplace = {
   FIXED_SPACE: "{\\tt~}"
 };
 
-export const replaceTagWithSymbol = (node, writeTo) => {
+const tagsToReplacePdf = {
+  SHORT_SPACE: "@xxx", // will be replaced in processSnippet
+  SHORT_SPACE_AND_ALLOW_BREAK: "@yyy" // will be replaced in processSnippet
+};
+
+export const replaceTagWithSymbol = (node, writeTo, type) => {
   const name = node.nodeName;
+  let tagsToReplace;
+
+  switch (type) {
+    case "pdf":
+      tagsToReplace = { ...tagsToReplaceDefault, ...tagsToReplacePdf };
+      break;
+    default:
+      tagsToReplace = tagsToReplaceDefault;
+  }
+
   if (tagsToReplace[name]) {
     writeTo.push(tagsToReplace[name]);
     return true;

--- a/javascript/processingFunctions/replaceTagWithSymbol.js
+++ b/javascript/processingFunctions/replaceTagWithSymbol.js
@@ -39,7 +39,7 @@ const tagsToReplacePdf = {
   SHORT_SPACE_AND_ALLOW_BREAK: "@yyy" // will be replaced in processSnippet
 };
 
-export const replaceTagWithSymbol = (node, writeTo, type) => {
+export const replaceTagWithSymbol = (node, writeTo, type = "default") => {
   const name = node.nodeName;
   let tagsToReplace;
 


### PR DESCRIPTION
Closes #591 

- ~Accounted for possibility that "@xxx" is not followed by newline character.~
- ~Replaced `SHORT_SPACE` and `SHORT_SPACE_ALLOW_BREAK` with newline character in non-pdf versions.~
- Removed dead code from `processSnippetJs`

EDIT:
- Set default transformation of relevant xml tags to empty string
- Set transformation of relevant tags in pdf version to "@xxx" and "@yyy"