### PR TITLE
Fix make_broken_heart_ptr() to take no arguments

### DIFF
--- a/xml/chapter5/section3/subsection2.xml
+++ b/xml/chapter5/section3/subsection2.xml
@@ -843,8 +843,8 @@ function make_prog_ptr(idx) {
     return pair(PROG_TYPE, idx);
 }
 
-function make_broken_heart_ptr(idx) {
-    return pair(BROKEN_HEART_TYPE, idx);
+function make_broken_heart_ptr() {
+    return pair(BROKEN_HEART_TYPE, null);
 }
 
 function get_elem_type(elem) {


### PR DESCRIPTION
I saw @samuelfangjw's comments in #594.  That led me to look at `make_broken_heart_ptr` and it's uses.  It's only use, afaict, called it with no arguments.  Moreover, it appeared that nobody looked at the tail of the pair that it was creating and that I could make it take no arguments and just put null in the tail.  This was also consistent with the code in the text (which, for some reason, is slightly different than what's used in the playground), where the broken heart is a simple constant.

I tested it and is appeared to run fine, at least for the one example in the section, so it might be that more testing is necessary.

Fixes #594
