### PR TITLE
Changed report_prime to return nothing (undefined)

### DIFF
--- a/xml/chapter1/section2/subsection6.xml
+++ b/xml/chapter1/section2/subsection6.xml
@@ -657,7 +657,7 @@ function start_prime_test(n, start_time) {
 <SHORT_SPACE_AND_ALLOW_BREAK/>
 function report_prime(elapsed_time) {
     display(" *** ");
-    return display(elapsed_time);
+    display(elapsed_time);
 }
       </JAVASCRIPT>
     </SNIPPET>


### PR DESCRIPTION
Fixes infinite recursion error mentioned in #608 due to mismatch in type.