### PR TITLE
Add missing word

### DIFF
--- a/xml/others/02foreword84.xml
+++ b/xml/others/02foreword84.xml
@@ -60,7 +60,7 @@ into larger structures using organizational techniques of proven
 value.  These techniques are treated at length in this book, and
 understanding them is essential to participation in the Promethean
 enterprise called programming.  More than anything else, the
-uncovering and mastery of powerful organizational
+uncovering and mastery of powerful organizational techniques
 accelerates our ability to create large, significant programs.
 Conversely, since writing large programs is very taxing, we are
 stimulated to invent new methods of reducing the mass of function and


### PR DESCRIPTION
The word 'techniques' was missing. It's in the foreword of the original SICP.