### PR TITLE
Addition to snippet macros

### DIFF
--- a/javascript/processingFunctions/processSnippetPdf.js
+++ b/javascript/processingFunctions/processSnippetPdf.js
@@ -124,6 +124,10 @@ export const processSnippetPdf = (node, writeTo) => {
   const jsLonelySnippet = node.getElementsByTagName("JAVASCRIPT_LONELY")[0];
   const jsSnippet = node.getElementsByTagName("JAVASCRIPT")[0];
   const jsOutputSnippet = node.getElementsByTagName("JAVASCRIPT_OUTPUT")[0];
+  const allowBreakAfter =
+    jsSnippet && jsSnippet.getAttribute("BREAK_AFTER") === "yes"
+      ? "\\pagebreak"
+      : "";
 
   if (jsPromptSnippet) {
     writeTo.push(preSpace);
@@ -237,6 +241,7 @@ export const processSnippetPdf = (node, writeTo) => {
         "}\n" +
         "\\end{lrbox}" +
         "\\Usebox{\\UnbreakableBox}\\\\" +
+        allowBreakAfter +
         midSpace +
         "\\begin{lrbox}{\\UnbreakableBox}" +
         "\\begin{" +
@@ -275,11 +280,11 @@ export const processSnippetPdf = (node, writeTo) => {
 
       if (jsOutputSnippet) {
         if (indexTerms.length > 0) writeTo.push(indexTerms.pop());
-        writeTo.push("\\Usebox{\\UnbreakableBox}");
+        writeTo.push("\\Usebox{\\UnbreakableBox}" + allowBreakAfter);
         outputAdjacent = true;
       } else {
         if (indexTerms.length > 0) writeTo.push(indexTerms.pop());
-        writeTo.push("\\Usebox{\\UnbreakableBox}");
+        writeTo.push("\\Usebox{\\UnbreakableBox}" + allowBreakAfter);
         if (!followedByOtherSnippet && !skipPostPadding) {
           writeTo.push(postSpace);
         } else {

--- a/javascript/processingFunctions/replaceTagWithSymbol.js
+++ b/javascript/processingFunctions/replaceTagWithSymbol.js
@@ -24,6 +24,7 @@ const tagsToReplaceDefault = {
 
   SHORT_SPACE: "",
   SHORT_SPACE_AND_ALLOW_BREAK: "",
+  ALLOW_BREAK: "",
 
   EMDASH: "—",
   ENDASH: "–",
@@ -36,7 +37,8 @@ const tagsToReplaceDefault = {
 
 const tagsToReplacePdf = {
   SHORT_SPACE: "@xxx", // will be replaced in processSnippet
-  SHORT_SPACE_AND_ALLOW_BREAK: "@yyy" // will be replaced in processSnippet
+  SHORT_SPACE_AND_ALLOW_BREAK: "@yyy", // will be replaced in processSnippet
+  ALLOW_BREAK: "@yyy" // ok to alias short_space_and_allow_break because the short space is implicit in the splitting of code boxes for now
 };
 
 export const replaceTagWithSymbol = (node, writeTo, type = "default") => {


### PR DESCRIPTION
This PR adds a new command `ALLOW_BREAK` which is a placeholder for now -- it is simply an alias of `SHORT_SPACE_AND_ALLOW_BREAK`. 

This command is used in a few places in the pagination. 

Further, we add the attribute `BREAK_AFTER` to `JAVASCRIPT` tags inside a snippet, that should work thus: 

In this case, the snippet is just a single snippet so this should be ignored.
```
<SNIPPET>
    <JAVASCRIPT BREAK_AFTER="yes">
   ...
    </JAVASCRIPT>
</SNIPPET>
```

In this case, the first snippet should be compiled to LaTeX such that a \pagebreak is inserted between it and the output snippet. 
```
<SNIPPET>
    <JAVASCRIPT BREAK_AFTER="yes">
   ...
    </JAVASCRIPT>
    <JAVASCRIPT_OUTPUT>
   ...
    </JAVASCRIPT_OUTPUT>
</SNIPPET>
```


