### PR TITLE
Addresses the cosmetic bug on p 371 (now 369)

### DIFF
--- a/javascript/processingFunctions/processSnippetPdf.js
+++ b/javascript/processingFunctions/processSnippetPdf.js
@@ -111,6 +111,7 @@ export const processSnippetPdf = (node, writeTo) => {
   let outputAdjacent = false;
 
   const inFootnote = ancestorHasTag(node, "FOOTNOTE");
+  const inList = ancestorHasTag(node, "OL");
   const inFigure = ancestorHasTag(node, "FIGURE");
   const preSpace = inFigure ? "" : inFootnote ? "\\PreBoxCmdFn" : "\\PreBoxCmd";
   const postSpace = inFigure
@@ -160,7 +161,12 @@ export const processSnippetPdf = (node, writeTo) => {
     writeTo.push("\\Usebox{\\UnbreakableBox}");
 
     if (jsLonelySnippet || jsSnippet || jsOutputSnippet) {
-      writeTo.push("\\PromptInputSpace");
+      if (inList) {
+        /// writeTo.push("****\\\\");
+        writeTo.push("\\\\"); // FIXME: when we remove the use of \par from PromptInputSpace this edge case goes away
+      } else {
+        writeTo.push("\\PromptInputSpace");
+      }
       outputAdjacent = true;
     } else {
       writeTo.push("\\PostBoxCmd\n");


### PR DESCRIPTION
This branch adds an edge case to snippet processing that uses a normal hard line break (`\\`) instead of our built-in spacing command (`\PromptInputSpace`) when it compiles a `<JAVASCRIPT_PROMPT>` **if** the snippet occurs inside a list (`OL`) environment. 

There is only one such case in the entire book on p 369 (p 371 in the initial submit). 

You can uncomment line 165 instead of 166 in `processSnippetPDF.js` to have the command also output `****` into the PDF right before the hard line break. You can then seach for `****` to verify that there is indeed only a single case of this in the book. 

Here is what the case on p. 369 looks like with that debug code turned on. Observe that the spacing is good, which is the bug we are trying to fix. 

![image](https://user-images.githubusercontent.com/364888/141209192-699cd134-fedc-4c0c-b2da-21642c667532.png)


Obviously, this code incurs some technical debt that we don't want but I consider this the right fix for now. 

