### PR TITLE
4.1.2: font choice in intro example

### DIFF
--- a/xml/chapter4/section1/subsection2.xml
+++ b/xml/chapter4/section1/subsection2.xml
@@ -50,15 +50,13 @@
 	  <JAVASCRIPT>
 parse("const size = 2; 5 * size;");
 	  </JAVASCRIPT>
-	</SNIPPET>
-	<SNIPPET EVAL="no">
-	  <JAVASCRIPT>
+	  <JAVASCRIPT_OUTPUT>
 list("sequence",
      list(list("constant_declaration",
                list("name", "size"), list("literal", 2)),
           list("binary_operator_combination", "*",
                list("literal", 5), list("name", "size"))))
-	  </JAVASCRIPT>
+	  </JAVASCRIPT_OUTPUT>
 	</SNIPPET>
 	The syntax functions used by the evaluator access the tagged-list
 	representation produced by 


### PR DESCRIPTION
I believe that this is the only place where we don't use slanted font for program output. I think we should use slanted font here, to make sure that the reader sees that the list(...) is the output produced by parse(...).