### PR TITLE
Acknowledgments: 'Finally' removed

### DIFF
--- a/xml/others/04acknowledgements04.xml
+++ b/xml/others/04acknowledgements04.xml
@@ -50,7 +50,7 @@
       project.
     </TEXT>
     <TEXT>
-      Finally, we would like to acknowledge the courageous work of the
+      We would like to acknowledge the courageous work of the
       committee of ECMAScript 2015, led by Allen Wirfs-Brock. SICP JS
       relies heavily on constant and let declarations and lambda expressions,
       all of which were added to JavaScript with ECMAScript 2015. Those


### PR DESCRIPTION
There are actually two separate acknowledgments in the last paragraph, so the "Finally" doesn't make sense.