### PR TITLE
fixing figure numbering bug

### DIFF
--- a/javascript/processingFunctions/processReferenceJson.js
+++ b/javascript/processingFunctions/processReferenceJson.js
@@ -58,7 +58,9 @@ export const setupReferencesJson = (node, filename) => {
 
     let href;
     let displayName;
-    if (ref_type == "chap") {
+    if (ancestorHasTag(label, "SCHEME")) {
+      continue;
+    } else if (ref_type == "chap") {
       displayName = chapterIndex;
       href = `/sicpjs/${chapterIndex}`;
     } else if (ref_type == "sec") {


### PR DESCRIPTION
In Interactive SICP JS, Figure numbering erroneously included the figures in the SCHEME edition.