### PR TITLE
fixes #997

### DIFF
--- a/xml/chapter2/section1/subsection4.xml
+++ b/xml/chapter2/section1/subsection4.xml
@@ -411,7 +411,7 @@ function the_trouble_maker(xl, xu, yl, yu) {
     const p2 = xl * yu;
     const p3 = xu * yl;
     const p4 = xu * yu;
-    make_interval(math_min(p1, p2, p3, p4),
+    return make_interval(math_min(p1, p2, p3, p4),
                   math_max(p1, p2, p3, p4));
 }
 function mul_interval(x, y) {  


### PR DESCRIPTION
Fixes the issue described in [#997](https://github.com/source-academy/sicp/issues)

The `the_trouble_maker` function in the solution to task 2.11 is missing the return keyword.