### PR TITLE
Fixes #999

### DIFF
--- a/xml/chapter2/section3/subsection2.xml
+++ b/xml/chapter2/section3/subsection2.xml
@@ -1340,7 +1340,7 @@ list("x", "+", list(3, "*", list("x", "+", list("y", "+", 2))))
 	    example:
 	    <SNIPPET EVAL="no">
 	      <JAVASCRIPT>
-list("x", "+", "3", "*", list("x", "+", "y", "+", 2))
+list("x", "+", 3, "*", list("x", "+", "y", "+", 2))
               </JAVASCRIPT>
 	    </SNIPPET>
 	  </JAVASCRIPT>

--- a/xml/chapter2/section3/subsection2.xml
+++ b/xml/chapter2/section3/subsection2.xml
@@ -1436,15 +1436,27 @@ deriv(list("x", "*", 4), "x");
 	    <EXAMPLE>example_2.61_2</EXAMPLE>
 	    <JAVASCRIPT>
 function items_before_first(op, s) {
-    return head(s) === op
+    return is_string(head(s)) &amp;&amp; head(s) === op
            ? null
            : pair(head(s),
                   items_before_first(op, tail(s)));
 }
 function items_after_first(op, s) {
-    return head(s) === op
+    return is_string(head(s)) &amp;&amp; head(s) === op
            ? tail(s)
-           : items_after_first(op, tail(s);
+           : items_after_first(op, tail(s));
+}
+function simplify_unary_list(s) {
+    return is_pair(s) &amp;&amp; is_null(tail(s))
+           ? head(s)
+           : s;
+}
+function contains_plus(s) {
+    return is_null(s)
+           ? false
+           : is_string(head(s)) &amp;&amp; head(s) === "+"
+             ? true
+             : contains_plus(tail(s));
 }
 function make_sum(a1, a2) {
     return number_equal(a1, 0)
@@ -1458,14 +1470,13 @@ function make_sum(a1, a2) {
 // a sequence of terms and operators is a sum
 // if and only if at least one + operator occurs
 function is_sum(x) {
-    return is_pair(x) &amp;&amp;
-           ! (is_null(member("+", x));
+    return is_pair(x) &amp;&amp; contains_plus(x);
 }
 function addend(s) {
-    return items_before_first("+", s);
+    return simplify_unary_list(items_before_first("+", s));
 }
 function augend(s) {
-    return items_after_first("+", s);
+    return simplify_unary_list(items_after_first("+", s));
 }
 function make_product(m1, m2) {
     return number_equal(m1, 0) || number_equal(m2, 0)
@@ -1481,13 +1492,13 @@ function make_product(m1, m2) {
 // a sequence of terms and operators is a product
 // if and only if no + operator occurs
 function is_product(x) {
-    return is_pair(x) &amp;&amp; is_null(member("+", x);
+    return is_pair(x) &amp;&amp; ! contains_plus(x);
 }
 function multiplier(s) {
-    return items_before_first("*", s);
+    return simplify_unary_list(items_before_first("*", s));
 }
 function multiplicand(s) {
-    return items_after_first("*", s);
+    return simplify_unary_list(items_after_first("*", s));
 }
 function deriv(exp, variable) {
     return is_number(exp)


### PR DESCRIPTION
Fixes issues described in #999:

1. Simple syntax errors with unmatched parentheses
2. A problem with the built in `member` function that only happens with the Source §2 interpreter
3. A logic error in the current solution, where the selectors return single-item lists (eg. `list("x")`) that `deriv` can't handle.

Also fixes an typo in the problem description (unnecessary parentheses for number literal).