### PR TITLE
Fix make_leaf_set function call argument

### DIFF
--- a/xml/chapter2/section3/subsection4.xml
+++ b/xml/chapter2/section3/subsection4.xml
@@ -773,16 +773,16 @@ function make_leaf_set(pairs) {
     <SNIPPET HIDE="yes">
       <NAME>make_leaf_set_example</NAME>
       <JAVASCRIPT>
-make_leaf_set( list( make_leaf("A", 4),
-                     make_leaf("B", 2),
-                     make_leaf("C", 1),
-                     make_leaf("D", 1) ) );
+make_leaf_set( list( list("A", 4),
+                     list("B", 2),
+                     list("C", 1),
+                     list("D", 1) ) );
       </JAVASCRIPT>
       <JAVASCRIPT_TEST>
-head(make_leaf_set( list( make_leaf("A", 4),
-                          make_leaf("B", 2),
-                          make_leaf("C", 1),
-                          make_leaf("D", 1) ) ) );
+head(make_leaf_set( list( list("A", 4),
+                          list("B", 2),
+                          list("C", 1),
+                          list("D", 1) ) ) );
       </JAVASCRIPT_TEST>
     </SNIPPET>
   </TEXT>


### PR DESCRIPTION
`make_leaf_set()` (in line 776) "takes a list of symbol-frequency pairs such as `list(list("A", 4), list("B", 2), list("C", 1), list("D", 1))`" and not a list of leafs. 

Because the argument is a list of leafs, the resulting list will look like this: 

```
[ ["leaf", ["leaf", ["A", null]]],
[ ["leaf", ["leaf", ["B", null]]],
[["leaf", ["leaf", ["C", null]]], [["leaf", ["leaf", ["D", null]]], null]]]]
```

`head(first_pair)` (in line 766) expects a list with the first item being the symbol and the second item the frequency.

See [https://sourceacademy.org/sicpjs/2.3.4#p15](https://sourceacademy.org/sicpjs/2.3.4#p15)