### PR TITLE
add scroll-margin-top for navbar to footnote links

### DIFF
--- a/static/assets/stylesheet.css
+++ b/static/assets/stylesheet.css
@@ -331,6 +331,10 @@ tt {
   font-size: 13pt !important;
 }
 
+/* Leave space for navbar above footnote links */
+.footnote-number {
+  scroll-margin-top: 4rem;
+}
 
 .nav .btn {
   /*display: none;*/
@@ -350,11 +354,10 @@ tt {
   left: 40vw;
 }
 
-
 :not(ref) > .superscript {
   font-variant-position: super;
+  scroll-margin-top: 4rem;
 }
-
 
 ul {
   list-style: none;


### PR DESCRIPTION
A small UX improvement: When clicking on a footnote link, the link target is usually aligned with the top edge of the browser viewport. Due to the navbar overlay at the top, this means the link target may be invisible (hidden behind the navbar), which is confusing.

This PR adds a [`scroll-margin-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-top) to the CSS, to ensure the link target is positioned just below the navbar, where the reader would expect it.

(This is most often relevant when jumping back to the main text; but on pages with many long footnotes (e.g. [chapter 2.3.1](https://sicp.sourceacademy.org/chapters/2.3.1.html#footnote-1)), it can also be an issue when jumping to the footnote text. This PR adds the margin for both cases.)