### PR TITLE
✨ Quality: Replace Source §3 Non-Det with the amb interpreter from 4.3.3

### DIFF
--- a/xml/chapter4/section3/subsection1.xml
+++ b/xml/chapter4/section3/subsection1.xml
@@ -38,7 +38,7 @@
     returns the value of one of the <LATEXINLINE>$n$</LATEXINLINE> expressions
     <LATEXINLINE>$e_i$</LATEXINLINE> <QUOTE>ambiguously.</QUOTE> For example,
     the expression
-    <SNIPPET CHAP="3" VARIANT="non-det">
+    <SNIPPET CHAP="4" VARIANT="amb">
       <NAME>list_non_det</NAME>
       <SCHEME>
 (list (amb 1 2 3) (amb 'a 'b))
@@ -110,7 +110,7 @@ x;
 // in the REPL on the right, for more solutions
       </JAVASCRIPT>
     </SNIPPET>
-    <SNIPPET CHAP="3" VARIANT="non-det">
+    <SNIPPET CHAP="4" VARIANT="amb">
       <INDEX><DECLARATION>require</DECLARATION></INDEX> 
       <NAME>require_non_det</NAME>
       <EXAMPLE>require_non_det_example</EXAMPLE>
@@ -148,7 +148,7 @@ an_element_of(xs);
 // in the REPL on the right, for more solutions
       </JAVASCRIPT>
     </SNIPPET>
-    <SNIPPET CHAP="3" VARIANT="non-det">
+    <SNIPPET CHAP="4" VARIANT="amb">
       <INDEX><DECLARATION>an_element_of</DECLARATION></INDEX> 
       <NAME>an_element_of</NAME>
       <EXAMPLE>an_element_of_example</EXAMPLE>


### PR DESCRIPTION
## Problem

The subsection 4.3.1 currently uses Source §3 Non-Det as the execution engine for its examples. This engine is broken (causes "Maximum call stack size exceeded"). The fix is to change all code snippets to use the amb interpreter defined in 4.3.3, loaded via the `repl` module. This means:

**Severity**: `critical`
**File**: `xml/chapter4/section3/subsection1.xml`

## Solution

The subsection 4.3.1 currently uses Source §3 Non-Det as the execution engine for its examples. This engine is broken (causes "Maximum call stack size exceeded"). The fix is to change all code snippets to use the amb interpreter defined in 4.3.3, loaded via the `repl` module. This means:

## Changes

- `xml/chapter4/section3/subsection1.xml` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


Closes #990