### PR TITLE
Feature: Add syntax highlighting support for non-executable snippets

### DIFF
--- a/javascript/processingFunctions/processSnippetHtml.js
+++ b/javascript/processingFunctions/processSnippetHtml.js
@@ -64,7 +64,7 @@ export const processSnippetHtml = (node, writeTo, split) => {
   const jsPromptSnippet = node.getElementsByTagName("JAVASCRIPT_PROMPT")[0];
 
   if (jsPromptSnippet) {
-    writeTo.push("<pre class='prettyprintoutput'>");
+    writeTo.push("<pre class='prettyprint'>");
     writeTo.push(jsPromptSnippet.firstChild.nodeValue.trimRight());
     writeTo.push("</pre>");
   }
@@ -72,7 +72,7 @@ export const processSnippetHtml = (node, writeTo, split) => {
   const jsLonelySnippet = node.getElementsByTagName("JAVASCRIPT_LONELY")[0];
 
   if (jsLonelySnippet) {
-    writeTo.push("<pre class='prettyprintoutput'>");
+    writeTo.push("<pre class='prettyprint'>");
     writeTo.push(jsLonelySnippet.firstChild.nodeValue.trimRight());
     writeTo.push("</pre>");
   }


### PR DESCRIPTION
## Problem

The current implementation of `processSnippetHtml` only applies syntax highlighting classes to snippets that have specific execution tags. This leaves static code blocks unstyled. I will modify the function to ensure that all code snippets, including those that are purely illustrative, are wrapped in the `<pre class="prettyprint">` tag (or equivalent) so that the CSS can apply syntax highlighting.

**Severity**: `medium`
**File**: `javascript/processingFunctions/processSnippetHtml.js`

## Solution

The current implementation of `processSnippetHtml` only applies syntax highlighting classes to snippets that have specific execution tags. This leaves static code blocks unstyled. I will modify the function to ensure that all code snippets, including those that are purely illustrative, are wrapped in the `<pre class="prettyprint">` tag (or equivalent) so that the CSS can apply syntax highlighting.

## Changes

- `javascript/processingFunctions/processSnippetHtml.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


Closes source-academy/frontend#3974