### PR TITLE
Security: Arbitrary Code Execution via runInThisContext

### DIFF
--- a/test_node_env/result_writer.js
+++ b/test_node_env/result_writer.js
@@ -1,14 +1,20 @@
 import { Script } from "vm";
 import "sicp";
 import { readFileSync, createWriteStream } from "fs";
+import { resolve, dirname } from "path";
 ("use strict");
 
 let writer = createWriteStream("test_node_env/result.txt");
 const args = process.argv.slice(2);
 const programPath = args[0];
+const allowedDir = resolve(dirname(process.argv[1]), "test_node_env");
+const resolvedPath = resolve(programPath);
+if (!resolvedPath.startsWith(allowedDir)) {
+  throw new Error("Invalid program path: must be within test_node_env directory");
+}
 
 writer.once("open", function (fd) {
-  let s = new Script(readFileSync(programPath));
+  let s = new Script(readFileSync(resolvedPath));
   let r = s.runInThisContext();
   if (typeof r !== "undefined") {
     writer.write(JSON.stringify(r));


### PR DESCRIPTION
## Summary

Security: Arbitrary Code Execution via runInThisContext

## Problem

**Severity**: `Critical` | **File**: `test_node_env/result_writer.js:L8`

The Script module's runInThisContext method is used to execute code read from a file path provided via command line arguments. This allows arbitrary code execution with full access to the current context, including file system and network access.

## Solution

Avoid using runInThisContext with untrusted file paths. If test execution is needed, use a proper test runner with sandboxing capabilities. Validate file paths strictly against a whitelist of allowed test directories.

## Changes

- `test_node_env/result_writer.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v5.15.0*