### PR TITLE
Add solution to Exercise 3.35 (squarer constraint)

### DIFF
--- a/xml/chapter3/section3/subsection5.xml
+++ b/xml/chapter3/section3/subsection5.xml
@@ -1330,6 +1330,62 @@ function squarer(a, b) {
 }
       </JAVASCRIPT>
     </SNIPPET>
+    <SOLUTION>
+      <SNIPPET HIDE="yes">
+	<NAME>squarer_example</NAME>
+	<JAVASCRIPT>
+const a = make_connector();
+const b = make_connector();
+squarer(a, b);
+probe("a", a);
+probe("b", b);
+set_value(a, 3, "user");
+	</JAVASCRIPT>
+      </SNIPPET>
+      <SNIPPET>
+	<NAME>squarer</NAME>
+	<REQUIRES>make_connector</REQUIRES>
+	<REQUIRES>has_value</REQUIRES>
+	<REQUIRES>probe_2</REQUIRES>
+	<EXAMPLE>squarer_example</EXAMPLE>
+	<JAVASCRIPT>
+// Solution provided by GitHub user KrNor,
+// assuming that math_sqrt can be used
+function squarer(a, b) {
+    function process_new_value() {
+        if (has_value(b)) {
+            if (get_value(b) &lt; 0) {
+                error(get_value(b), "square less than 0 -- squarer");
+            } else {
+                set_value(a, math_sqrt(get_value(b)), me);
+            }
+        } else {
+            if (has_value(a)) {
+                set_value(b, get_value(a) * get_value(a), me);
+            }
+        }
+    }
+    function process_forget_value() {
+        forget_value(a, me);
+        forget_value(b, me);
+        process_new_value();
+    }
+    function me(request) {
+        if (request === "I have a value.") {
+            process_new_value();
+        } else if (request === "I lost my value.") {
+            process_forget_value();
+        } else {
+            error(request, "unknown request -- squarer");
+        }
+    }
+    connect(a, me);
+    connect(b, me);
+    return me;
+}
+	</JAVASCRIPT>
+      </SNIPPET>
+    </SOLUTION>
     <LABEL NAME="ex:3_35"/>
   </EXERCISE>
 


### PR DESCRIPTION
Adds a `<SOLUTION>` for **Exercise 3.35** (`ex:3_35`) — defining `squarer` as a primitive constraint — in `xml/chapter3/section3/subsection5.xml`. The exercise previously had no solution.

The solution is the one contributed by GitHub user **KrNor** in #1148, lightly adapted to the book's conventions:

- Fills in the template's blanks (`alternative_1/2`, `body_1/2`, `statements`) following the same dispatch structure as the `adder`/`multiplier` constraints: set `a = math_sqrt(b)` when `b` is known, `b = a * a` when `a` is known, with a guard erroring on negative `b`.
- Uses the exact request strings the book's connector sends (`"I have a value."` / `"I lost my value."`), verified against the `adder` and `inform_about_value` snippets.
- Adds a hidden runnable `squarer_example` and wires `<REQUIRES>` (`make_connector`, `has_value` — which provides `get_value`/`set_value`/`forget_value`/`connect` — and `probe_2`).

### Checks
- XML well-formed.
- Solution JavaScript syntax-checked.
- `squarer` is a previously unused snippet name (no collision).

Closes #1148