### PR TITLE
Add solution to Exercise 3.34 (flaw in Louis's squarer)

### DIFF
--- a/xml/chapter3/section3/subsection5.xml
+++ b/xml/chapter3/section3/subsection5.xml
@@ -1277,6 +1277,21 @@ function squarer(a, b) {
       </JAVASCRIPT>
     </SNIPPET>
     There is a serious flaw in this idea.  Explain.
+    <SOLUTION>
+      The primitive multiplier constraint can compute the value of one of its
+      three connectors only when the other two already have values. In Louis<APOS/>s
+      device, both factor terminals of the multiplier are the same connector
+      <SCHEMEINLINE>a</SCHEMEINLINE>, and the product is
+      <SCHEMEINLINE>b</SCHEMEINLINE>. So when
+      <SCHEMEINLINE>a</SCHEMEINLINE> is given a value, two of the multiplier<APOS/>s
+      three connectors are known and it can set
+      <SCHEMEINLINE>b</SCHEMEINLINE> to the square. But when only
+      <SCHEMEINLINE>b</SCHEMEINLINE> is given a value, just one of the three
+      connectors is known, so the multiplier cannot deduce
+      <SCHEMEINLINE>a</SCHEMEINLINE>. The device therefore fails to compute the
+      square root, even though that relationship is part of the constraint Louis
+      intended to express.
+    </SOLUTION>
     <LABEL NAME="ex:squarer-constraint"/>
   </EXERCISE>
 


### PR DESCRIPTION
Adds a prose `<SOLUTION>` for **Exercise 3.34** (`ex:squarer-constraint`) — "explain the serious flaw" in Louis Reasoner's `squarer(a, b) = multiplier(a, a, b)` — in `xml/chapter3/section3/subsection5.xml`. The exercise previously had no solution.

The explanation is the one contributed by GitHub user **KrNor** in #1147: the primitive multiplier needs two of its three connectors to have values before it can compute the third. Because both factor terminals are the same connector `a`, setting `a` lets the multiplier compute `b` (two of three known), but setting only `b` leaves just one connector known, so it cannot deduce `a` — the device fails to run the constraint backwards to a square root.

Markup follows the exercise's own style (`<SCHEMEINLINE>` for the connector names `a`/`b`).

### Checks
- XML well-formed.

Closes #1147