### PR TITLE
Fix insert in Exercise 3.26 solution to update existing keys

### DIFF
--- a/xml/chapter3/section3/subsection3.xml
+++ b/xml/chapter3/section3/subsection3.xml
@@ -923,7 +923,7 @@ function make_table() {
         if(is_null(record)) {
             local_table = adjoin_set(list(k, v), local_table);
         } else {
-            // do nothing
+            set_tail(record, list(v));
         }
     }
     function get(k) {
@@ -964,7 +964,7 @@ put(5, "f");
 
 print();
 
-display(get(2)); // displays: "b"
+display(get(2)); // displays: "c"
 	</JAVASCRIPT>
       </SNIPPET>
     </SOLUTION>

--- a/xml/chapter3/section3/subsection3.xml
+++ b/xml/chapter3/section3/subsection3.xml
@@ -920,7 +920,7 @@ function make_table() {
     }
     function insert(k, v) {
         let record = lookup(k, local_table);
-        if(is_null(record)) {
+        if (is_null(record)) {
             local_table = adjoin_set(list(k, v), local_table);
         } else {
             set_tail(record, list(v));


### PR DESCRIPTION
Fixes a bug in the existing **Exercise 3.26** solution (binary-tree table) in `xml/chapter3/section3/subsection3.xml`, reported by GitHub user **KrNor** in #1146.

### Problem
`insert` did nothing when the key already existed:

```js
} else {
    // do nothing
}
```

So re-inserting an existing key (`put(2, "c")` after `put(2, "b")`) silently kept the old value. The update logic existed in the original solution (#805) but was dropped in commit `245bdc06`.

### Fix
Mutate the found record in place:

```js
} else {
    set_tail(record, list(v));
}
```

The record is `list(k, v)`, so `set_tail(record, list(v))` replaces just the value, keeping the record a 2-element list and leaving the tree shape intact (avoiding the tree-corruption issue discussed in #805). `set_tail` is a primitive already used throughout section 3.3, so no new `<REQUIRES>` is needed.

I also updated the example comment to reflect the corrected behavior — `get(2)` now displays `"c"` rather than `"b"` (the issue suggested removing the comment; updating it demonstrates the fix instead).

### Checks
- Traced the example: `put(2,"b")` then `put(2,"c")` → `get(2)` returns `"c"`.
- XML well-formed.

Closes #1146