### PR TITLE
Fix wrong image in Exercise 3.14 solution

### DIFF
--- a/xml/chapter3/section3/subsection1.xml
+++ b/xml/chapter3/section3/subsection1.xml
@@ -952,7 +952,7 @@ const w = mystery(v);
       Initially
       <JAVASCRIPTINLINE>v</JAVASCRIPTINLINE> looks like this:
       
-      <FIGURE src="img_javascript/ex-3-14-sol-2.png">
+      <FIGURE src="img_javascript/ex-3-14-sol-1.png">
 	<LABEL NAME= "ex:3-14-sol-1"/>
       </FIGURE>
 


### PR DESCRIPTION
Fixes the image reference reported by GitHub user **KrNor** in #1144.

In the **Exercise 3.14** solution (`xml/chapter3/section3/subsection1.xml`), the first figure — the "Initially `v` looks like this" diagram, labeled `ex:3-14-sol-1` — referenced `img_javascript/ex-3-14-sol-2.png`. As a result the *second* diagram was displayed twice and the first ("before") diagram never appeared. Pointed it at `ex-3-14-sol-1.png`.

### Checks
- Both `ex-3-14-sol-1.png` and `ex-3-14-sol-2.png` exist in `static/img_javascript/`.
- The second figure (labeled `ex:3-14-sol-2`) correctly keeps `-2.png`.
- XML well-formed.

Closes #1144