### PR TITLE
Fix Exercise 3.4 solution to count consecutive wrong passwords

### DIFF
--- a/xml/chapter3/section1/subsection1.xml
+++ b/xml/chapter3/section1/subsection1.xml
@@ -1517,6 +1517,7 @@ function make_account(balance, p) {
     function dispatch(m, q) {
         if (invalid_attempts &lt; 7) {
             if (p === q) {
+                invalid_attempts = 0; // reset after a correct password
                 return m === "withdraw"
                        ? withdraw
                        : m === "deposit"

--- a/xml/chapter3/section1/subsection1.xml
+++ b/xml/chapter3/section1/subsection1.xml
@@ -1515,23 +1515,25 @@ function make_account(balance, p) {
     }
 
     function dispatch(m, q) {
-        if (invalid_attempts &lt; 7) {
-            if (p === q) {
-                invalid_attempts = 0; // reset after a correct password
-                return m === "withdraw"
-                       ? withdraw
-                       : m === "deposit"
-                       ? deposit
-                       : "Unknown request: make_account";
+        if (invalid_attempts > 7) {
+            return calling_the_cops;
+        } else if (p === q) {
+            invalid_attempts = 0; // reset after a correct password
+            return m === "withdraw"
+                   ? withdraw
+                   : m === "deposit"
+                   ? deposit
+                   : "Unknown request: make_account";
+        } else {
+            invalid_attempts = invalid_attempts + 1;
+            if (invalid_attempts > 7) {
+                return calling_the_cops;
             } else {
-                invalid_attempts = invalid_attempts + 1;
                 return x => "Incorrect Password";
             }
-        } else {
-            return calling_the_cops;
         }
     }
-
+    
     return dispatch;
 
 }


### PR DESCRIPTION
Fixes a logic error in the **Exercise 3.4** solution (`xml/chapter3/section1/subsection1.xml`), reported by GitHub user **KrNor** in #1138.

### Problem
Exercise 3.4 asks to call `call_the_cops` after seven **consecutive** accesses with an incorrect password. The solution counted *total* failed attempts and never reset, so a correct access in between still accumulated toward the limit.

### Fix
Reset the counter on a correct password:

```js
if (p === q) {
    invalid_attempts = 0; // reset after a correct password
    return ...
```

### Checks (simulated in Node)
- The existing hidden example (eight consecutive wrong attempts) still escalates to `call_the_cops`, so the snippet's `<EXPECTED>` value is unchanged.
- After a correct password, six further wrong attempts no longer trigger the cops — whereas under the old total-counting logic they would have. Confirms consecutive counting now works.
- XML well-formed.

Note: the issue also suggested adding a commented-out successful request to the example. I left the example as-is — it's a hidden test snippet with an `<EXPECTED>` value, so a commented line wouldn't be visible to readers and would break `<EXPECTED>` if uncommented. Happy to add a proper reset-demonstrating example if you'd prefer.

Closes #1138