### PR TITLE
Correct Exercise 1.1 solution: const declarations print undefined

### DIFF
--- a/xml/chapter1/section1/subsection6.xml
+++ b/xml/chapter1/section1/subsection6.xml
@@ -994,7 +994,7 @@ a === 4
 	  <JAVASCRIPTINLINE>undefined</JAVASCRIPTINLINE>, not
 	  <JAVASCRIPTINLINE>3</JAVASCRIPTINLINE> and
 	  <JAVASCRIPTINLINE>4</JAVASCRIPTINLINE>: a constant declaration is a
-	  statement, not an expression, and so does not produce a value.
+	  statement, not an expression, and does not produce a value.
 	</JAVASCRIPT>
 	<SCHEME>
 	  Note that the definitions <SCHEMEINLINE>(define a 3)</SCHEMEINLINE> and

--- a/xml/chapter1/section1/subsection6.xml
+++ b/xml/chapter1/section1/subsection6.xml
@@ -977,8 +977,8 @@ a === 4
 	<LI>8</LI>
 	<LI>3</LI>
 	<LI>6</LI>
-	<LI>3</LI>
-	<LI>4</LI>
+	<LI><SPLITINLINE><SCHEME>no value</SCHEME><JAVASCRIPT><JAVASCRIPTINLINE>undefined</JAVASCRIPTINLINE></JAVASCRIPT></SPLITINLINE></LI>
+	<LI><SPLITINLINE><SCHEME>no value</SCHEME><JAVASCRIPT><JAVASCRIPTINLINE>undefined</JAVASCRIPTINLINE></JAVASCRIPT></SPLITINLINE></LI>
 	<LI>19</LI>
 	<LI>false</LI>
 	<LI>4</LI>
@@ -986,6 +986,21 @@ a === 4
 	<LI>6</LI>
 	<LI>16</LI>
       </OL>
+      <SPLIT>
+	<JAVASCRIPT>
+	  Note that the declarations
+	  <JAVASCRIPTINLINE>const a = 3;</JAVASCRIPTINLINE> and
+	  <JAVASCRIPTINLINE>const b = a + 1;</JAVASCRIPTINLINE> print
+	  <JAVASCRIPTINLINE>undefined</JAVASCRIPTINLINE>, not
+	  <JAVASCRIPTINLINE>3</JAVASCRIPTINLINE> and
+	  <JAVASCRIPTINLINE>4</JAVASCRIPTINLINE>: a constant declaration is a
+	  statement, not an expression, and so does not produce a value.
+	</JAVASCRIPT>
+	<SCHEME>
+	  Note that the definitions <SCHEMEINLINE>(define a 3)</SCHEMEINLINE> and
+	  <SCHEMEINLINE>(define b (+ a 1))</SCHEMEINLINE> do not produce a value.
+	</SCHEME>
+      </SPLIT>
     </SOLUTION>
   </EXERCISE>
 


### PR DESCRIPTION
Fixes the **Exercise 1.1** solution in `xml/chapter1/section1/subsection6.xml`, reported in #1072.

### Problem
The solution list gave `3` and `4` as the printed results for the declarations:

```js
const a = 3;       // item 6 — actually prints undefined
const b = a + 1;   // item 7 — actually prints undefined
```

A constant declaration is a statement, not an expression, so it produces no value — the interpreter prints `undefined` (as confirmed by the issue's screenshots, and as the snippets' own `<EXPECTED>undefined</EXPECTED>` already states).

### Change
Per the maintainer's note on the issue (chapter 1 doesn't otherwise mention this, so the solution is a good place to point it out):

- Corrected list items 6 and 7 to `undefined` (JavaScript) / "no value" (Scheme), using `<SPLITINLINE>` since the solution `<OL>` is shared between both languages.
- Added a short `<SPLIT>` note explaining that a constant declaration / definition does not produce a value.

### Checks
- XML well-formed.
- Consistent with the existing `<EXPECTED>undefined</EXPECTED>` on the `definea`/`defineb` snippets.

Closes #1072