### PR TITLE
Add solution to Exercise 4.1 (argument evaluation order)

### DIFF
--- a/xml/chapter4/section1/subsection1.xml
+++ b/xml/chapter4/section1/subsection1.xml
@@ -1399,6 +1399,42 @@ evaluate(my_program, the_global_environment);
 	<JAVASCRIPTINLINE>list_of_values</JAVASCRIPTINLINE> that evaluates
 	argument expressions from right to left.
 	<LABEL NAME="ex:arg-eval-order"/>
+	<SOLUTION>
+	  The order in which the argument expressions are evaluated must not
+	  depend on the order in which <JAVASCRIPTINLINE>pair</JAVASCRIPTINLINE>
+	  evaluates its arguments. We therefore name the intermediate results
+	  with constant declarations and place them in the desired order, since
+	  the declarations are evaluated from top to bottom. For left-to-right
+	  evaluation, we evaluate the first argument expression before the rest:
+	  <SNIPPET EVAL="no">
+	    <JAVASCRIPT>
+function list_of_values_left_to_right(exps, env) {
+    if (is_null(exps)) {
+        return null;
+    } else {
+        const first = evaluate(head(exps), env);
+        const rest = list_of_values_left_to_right(tail(exps), env);
+        return pair(first, rest);
+    }
+}
+	    </JAVASCRIPT>
+	  </SNIPPET>
+	  For right-to-left evaluation, we evaluate the rest of the argument
+	  expressions before the first one:
+	  <SNIPPET EVAL="no">
+	    <JAVASCRIPT>
+function list_of_values_right_to_left(exps, env) {
+    if (is_null(exps)) {
+        return null;
+    } else {
+        const rest = list_of_values_right_to_left(tail(exps), env);
+        const first = evaluate(head(exps), env);
+        return pair(first, rest);
+    }
+}
+	    </JAVASCRIPT>
+	  </SNIPPET>
+	</SOLUTION>
       </EXERCISE>
     </JAVASCRIPT>
   </SPLIT>


### PR DESCRIPTION
Adds a `<SOLUTION>` to the JavaScript variant of **Exercise 4.1** (`ex:arg-eval-order`) in `xml/chapter4/section1/subsection1.xml`. The exercise had no solution.

### Key point
As you noted in the issue thread, solutions that build the list with `pair`/`append` are **incorrect**, because the order in which the argument expressions are evaluated then depends on the order in which `pair`/`append` evaluate *their* arguments — which is exactly what the exercise says we cannot rely on.

The solution forces the order explicitly by naming the intermediate results with constant declarations (which are evaluated top to bottom):

```js
// left to right: evaluate the first argument expression before the rest
const first = evaluate(head(exps), env);
const rest  = list_of_values_left_to_right(tail(exps), env);
return pair(first, rest);

// right to left: evaluate the rest before the first
const rest  = list_of_values_right_to_left(tail(exps), env);
const first = evaluate(head(exps), env);
return pair(first, rest);
```

This matches the structure of the book's own `list_of_values` (`is_null`/`head`/`tail`/`evaluate`/`pair`). It's essentially the correct idea from `tch1001`'s thread comment, written as a plain `if/else` function body rather than an IIFE.

### Notes & checks
- The snippets are `EVAL="no"` (display only), consistent with other evaluator-modification code here — running them requires the whole assembled metacircular evaluator and they reference `evaluate` itself.
- Added to the JS exercise only; the Scheme variant (`ex:arg-eval-order_scheme`) is a separate exercise in the `SPLIT` and is out of scope for this JS-focused issue. Happy to add a parallel Scheme solution if you'd like.
- JS syntax-checked; XML well-formed.

Closes #871