### PR TITLE
Add solution to Exercise 3.12 (append vs append_mutator)

### DIFF
--- a/xml/chapter3/section3/subsection1.xml
+++ b/xml/chapter3/section3/subsection1.xml
@@ -767,7 +767,7 @@ tail(x);
     <SOLUTION>
       The first response is <JAVASCRIPTINLINE>["b", null]</JAVASCRIPTINLINE> and the second is
       <JAVASCRIPTINLINE>["b", ["c", ["d", null]]]</JAVASCRIPTINLINE>.
-      <P/>
+
       The function <JAVASCRIPTINLINE>append</JAVASCRIPTINLINE> builds a new list by copying the pairs of
       <JAVASCRIPTINLINE>x</JAVASCRIPTINLINE> and making the <JAVASCRIPTINLINE>tail</JAVASCRIPTINLINE> of the last copied pair refer to
       <JAVASCRIPTINLINE>y</JAVASCRIPTINLINE>. Only the pairs holding <JAVASCRIPTINLINE>"a"</JAVASCRIPTINLINE> and
@@ -775,13 +775,13 @@ tail(x);
       last two pairs <JAVASCRIPTINLINE>["c", ["d", null]]</JAVASCRIPTINLINE> with <JAVASCRIPTINLINE>y</JAVASCRIPTINLINE>.
       Since <JAVASCRIPTINLINE>append</JAVASCRIPTINLINE> does not modify <JAVASCRIPTINLINE>x</JAVASCRIPTINLINE>, the value of
       <JAVASCRIPTINLINE>tail(x)</JAVASCRIPTINLINE> is still <JAVASCRIPTINLINE>["b", null]</JAVASCRIPTINLINE>.
-      <P/>
+
       The function <JAVASCRIPTINLINE>append_mutator</JAVASCRIPTINLINE>, by contrast, splices the lists
       together by setting the <JAVASCRIPTINLINE>tail</JAVASCRIPTINLINE> of the last pair of <JAVASCRIPTINLINE>x</JAVASCRIPTINLINE> to
       <JAVASCRIPTINLINE>y</JAVASCRIPTINLINE>, mutating <JAVASCRIPTINLINE>x</JAVASCRIPTINLINE> itself. After
       <JAVASCRIPTINLINE>const w = append_mutator(x, y);</JAVASCRIPTINLINE> the value of <JAVASCRIPTINLINE>tail(x)</JAVASCRIPTINLINE> is
       therefore <JAVASCRIPTINLINE>["b", ["c", ["d", null]]]</JAVASCRIPTINLINE>, and
-      <JAVASCRIPTINLINE>x</JAVASCRIPTINLINE>, <JAVASCRIPTINLINE>w</JAVASCRIPTINLINE>, and the tail of <JAVASCRIPTINLINE>y</JAVASCRIPTINLINE> now share structure.
+      <JAVASCRIPTINLINE>x</JAVASCRIPTINLINE>, <JAVASCRIPTINLINE>w</JAVASCRIPTINLINE>, and <JAVASCRIPTINLINE>y</JAVASCRIPTINLINE> now share structure.
     </SOLUTION>
   </EXERCISE>
 

--- a/xml/chapter3/section3/subsection1.xml
+++ b/xml/chapter3/section3/subsection1.xml
@@ -701,7 +701,7 @@ z
 z;
       </JAVASCRIPT>
       <JAVASCRIPT_OUTPUT>
-["a", ["b", ["c", ["d, null]]]]	
+["a", ["b", ["c", ["d", null]]]]	
       </JAVASCRIPT_OUTPUT>
     </SNIPPET>
     <SNIPPET EVAL="yes">
@@ -764,6 +764,25 @@ tail(x);
     </SNIPPET>
     What are the missing <META>response</META>s?
     Draw box-and-pointer diagrams to explain your answer.
+    <SOLUTION>
+      The first response is <JAVASCRIPTINLINE>["b", null]</JAVASCRIPTINLINE> and the second is
+      <JAVASCRIPTINLINE>["b", ["c", ["d", null]]]</JAVASCRIPTINLINE>.
+      <P/>
+      The function <JAVASCRIPTINLINE>append</JAVASCRIPTINLINE> builds a new list by copying the pairs of
+      <JAVASCRIPTINLINE>x</JAVASCRIPTINLINE> and making the <JAVASCRIPTINLINE>tail</JAVASCRIPTINLINE> of the last copied pair refer to
+      <JAVASCRIPTINLINE>y</JAVASCRIPTINLINE>. Only the pairs holding <JAVASCRIPTINLINE>"a"</JAVASCRIPTINLINE> and
+      <JAVASCRIPTINLINE>"b"</JAVASCRIPTINLINE> are freshly created; the result <JAVASCRIPTINLINE>z</JAVASCRIPTINLINE> shares its
+      last two pairs <JAVASCRIPTINLINE>["c", ["d", null]]</JAVASCRIPTINLINE> with <JAVASCRIPTINLINE>y</JAVASCRIPTINLINE>.
+      Since <JAVASCRIPTINLINE>append</JAVASCRIPTINLINE> does not modify <JAVASCRIPTINLINE>x</JAVASCRIPTINLINE>, the value of
+      <JAVASCRIPTINLINE>tail(x)</JAVASCRIPTINLINE> is still <JAVASCRIPTINLINE>["b", null]</JAVASCRIPTINLINE>.
+      <P/>
+      The function <JAVASCRIPTINLINE>append_mutator</JAVASCRIPTINLINE>, by contrast, splices the lists
+      together by setting the <JAVASCRIPTINLINE>tail</JAVASCRIPTINLINE> of the last pair of <JAVASCRIPTINLINE>x</JAVASCRIPTINLINE> to
+      <JAVASCRIPTINLINE>y</JAVASCRIPTINLINE>, mutating <JAVASCRIPTINLINE>x</JAVASCRIPTINLINE> itself. After
+      <JAVASCRIPTINLINE>const w = append_mutator(x, y);</JAVASCRIPTINLINE> the value of <JAVASCRIPTINLINE>tail(x)</JAVASCRIPTINLINE> is
+      therefore <JAVASCRIPTINLINE>["b", ["c", ["d", null]]]</JAVASCRIPTINLINE>, and
+      <JAVASCRIPTINLINE>x</JAVASCRIPTINLINE>, <JAVASCRIPTINLINE>w</JAVASCRIPTINLINE>, and the tail of <JAVASCRIPTINLINE>y</JAVASCRIPTINLINE> now share structure.
+    </SOLUTION>
   </EXERCISE>
 
   <EXERCISE>


### PR DESCRIPTION
Adds a `<SOLUTION>` to **Exercise 3.12** (`ex:append`) in `xml/chapter3/section3/subsection1.xml`. The exercise asks for the two missing `tail(x)` responses and a box-and-pointer explanation, and had no solution.

### Responses
- After `const z = append(x, y)`: `tail(x)` is `["b", null]` — `append` copies the pairs of `x` and does not modify it.
- After `const w = append_mutator(x, y)`: `tail(x)` is `["b", ["c", ["d", null]]]` — `append_mutator` splices `y` onto the last pair of `x`, mutating `x`.

### On the diagram correction
The explanation explicitly notes that the result `z` **shares** its last two pairs `["c", ["d", null]]` with `y` (only the pairs holding `"a"` and `"b"` are freshly copied) — addressing your comment on the issue that the contributor's first diagram was wrong because it didn't show this sharing. I wrote the solution as prose (matching the JS-focused style of the adjacent `ex:mystery` solution) rather than embedding the contributed images, since no solution images exist in the repo and the first one was incorrect.

### Also
- Fixed a pre-existing typo in this exercise's printed value of `z`: `["a", ["b", ["c", ["d, null]]]]` → `["d", null]` (missing closing quote; the `w` value just below already had it right).

### Checks
- XML well-formed.
- `<JAVASCRIPTINLINE>` quote style matches the surrounding solutions (literal `"`).

Closes #860