### PR TITLE
Fix non-termination in Exercise 2.82 solution

### DIFF
--- a/xml/chapter2/section5/subsection2.xml
+++ b/xml/chapter2/section5/subsection2.xml
@@ -1304,8 +1304,12 @@ function apply_generic(op, args) {
         return apply(fun, map(contents, args));
     } else {
         const target_type = find_coerced_type(type_tags);
-        if (! is_undefined(target_type)) {
-          return apply_generic(op, coerce_all(args, target_type));
+        // proceed only if coercion makes progress; if the arguments are
+        // already all of the target type, there is no applicable method
+        if (! is_undefined(target_type) &amp;&amp;
+            ! accumulate((t, acc) => acc &amp;&amp; t === target_type,
+                         true, type_tags)) {
+            return apply_generic(op, coerce_all(args, target_type));
         } else {
             return error(list(op, type_tags),
                          "no method for these types");
@@ -1318,7 +1322,15 @@ function apply_generic(op, args) {
     types, A, B, C where A can be coerced to B and C can be coerced to B, and
     there is a registered operation for (A, B, B). Evaluating the operation for
     (A, B, C) will only try (A, B, C) and (B, B, B) while you can just coerce C
-    to B and use the registered operation for (A, B, B)
+    to B and use the registered operation for (A, B, B).
+    <P/>
+    The condition that the arguments are not already all of
+    <JAVASCRIPTINLINE>target_type</JAVASCRIPTINLINE> is needed to guarantee
+    termination: without it, coercing arguments that already have the target
+    type would leave the type tags unchanged and call
+    <JAVASCRIPTINLINE>apply_generic</JAVASCRIPTINLINE> again with the same
+    arguments, looping forever whenever no method is registered for that
+    combination of types.
     </SOLUTION>
   </EXERCISE>
 


### PR DESCRIPTION
Fixes the non-termination reported in #833 in the **Exercise 2.82** solution (`xml/chapter2/section5/subsection2.xml`).

### The bug
`apply_generic` loops forever when coercion lands on a uniform signature `(T, T, …)` that has no registered method:
`find_coerced_type` returns `T`, `coerce_all(args, T)` is then the identity, and `apply_generic` recurses with the *same* arguments. This affects:
- the all-same-type case in the issue (e.g. `some_op` undefined for three rationals), and
- mixed arguments that coerce to a common type lacking a method (e.g. `(A, B, C)` → `(B, B, B)` with no `(B,B,B)` method).

### The fix
Add a **progress guard** in `apply_generic`: recurse only if the arguments are not already all of `target_type`; otherwise report "no method for these types".

```js
if (! is_undefined(target_type) &&
    ! accumulate((t, acc) => acc && t === target_type, true, type_tags)) {
    return apply_generic(op, coerce_all(args, target_type));
} else {
    return error(list(op, type_tags), "no method for these types");
}
```

`can_coerce_to` is left **unchanged**. This avoids the reporter's rewrite of `can_coerce_to` — which you flagged in the thread: returning `false` there does happen to fix termination, but it overloads `can_coerce_to`'s meaning, and the `? true` alternative you asked about would make the change a no-op (reintroducing the loop). Keeping the guard in `apply_generic` is clearer and keeps `can_coerce_to` honest.

### Verification (simulated the full machinery in Node)
- All-same-type, no method → original loops; fix → clean `"no method"` error. ✓
- `(A,B,C)` → `(B,B,B)` with no method → original loops; fix → clean error. ✓
- Direct method present → works (no coercion attempted). ✓
- Coercion that makes progress to a signature **with** a method (e.g. `(A,B)` → `(B,B)`) → still works; the book's own `add_three(c, c, n)` example is unaffected. ✓

Also added a short note to the solution prose explaining why the guard is needed. XML well-formed; JS syntax checked.

Closes #833