### PR TITLE
Register all exercise labels, not just the first

### DIFF
--- a/javascript/processingFunctions/processReferenceHtml.js
+++ b/javascript/processingFunctions/processReferenceHtml.js
@@ -125,6 +125,17 @@ export const setupReferences = (node, filename) => {
     const href = `${chapterIndex}.html#ex_${displayName}`;
     //console.log(referenceName + " added");
     referenceStore[referenceName] = { href, displayName, chapterIndex };
+
+    // An exercise may carry more than one label (e.g. a semantic label
+    // and an ex:N_M number label). Register every "ex" label as an alias
+    // pointing to the same exercise so all of them can be referenced.
+    const aliasLabels = exercise.getElementsByTagName("LABEL");
+    for (let j = 0; aliasLabels[j]; j++) {
+      const aliasName = aliasLabels[j].getAttribute("NAME");
+      if (aliasName.split(":")[0] === "ex" && !referenceStore[aliasName]) {
+        referenceStore[aliasName] = { href, displayName, chapterIndex };
+      }
+    }
   }
 };
 

--- a/javascript/processingFunctions/processReferenceJson.js
+++ b/javascript/processingFunctions/processReferenceJson.js
@@ -126,6 +126,17 @@ export const setupReferencesJson = (node, filename) => {
     const displayName = `${chapter_number}.${ex_count}`;
     const href = `/sicpjs/${chapterIndex}#ex-${displayName}`;
     referenceStore[referenceName] = { href, displayName, chapterIndex };
+
+    // An exercise may carry more than one label (e.g. a semantic label
+    // and an ex:N_M number label). Register every "ex" label as an alias
+    // pointing to the same exercise so all of them can be referenced.
+    const aliasLabels = exercise.getElementsByTagName("LABEL");
+    for (let j = 0; aliasLabels[j]; j++) {
+      const aliasName = aliasLabels[j].getAttribute("NAME");
+      if (aliasName.split(":")[0] === "ex" && !referenceStore[aliasName]) {
+        referenceStore[aliasName] = { href, displayName, chapterIndex };
+      }
+    }
   }
 };
 


### PR DESCRIPTION
## Problem
`yarn json` warns repeatedly:
```
WARNING, REF not found:ex:order-of-evaluation
```
while parsing chapter 3.2.1 (and the same reference is used in 5.4.1 and 5.4.2).

## Root cause
The exercise-reference setup registers only the **first** label of each exercise:
```js
const label = exercise.getElementsByTagName("LABEL")[0];
```
But ~20 exercises carry **two** labels — typically a semantic label plus an `ex:N_M` number label. The second label is silently dropped from the reference store, so any `<REF>` to it fails to resolve and renders as a broken cross-reference.

Exercise 3.8 has labels `ex:3_8` and `ex:order-of-evaluation` (in that order). `ex:3_8` is registered; `ex:order-of-evaluation` is dropped — and it's referenced four times, so it warns loudly. This affected the JSON build (and search data, which shares that store) **and** the HTML build, meaning these cross-references are also broken in the live web book.

## Fix
After registering an exercise's primary label, **additively** register every other `ex:` label of that exercise as an alias pointing to the same exercise (same `href`/`displayName`), in both `processReferenceJson.js` and `processReferenceHtml.js`. The `ex_count`/numbering logic is untouched, so exercise numbers are unchanged.

## Verification
- `yarn json` completes (exit 0) and now reports **zero** `REF not found` warnings (previously several for `ex:order-of-evaluation`).
- No new missing references — numbering is intact.
- HTML processor gets the byte-identical additive change.

This is a general fix for all multi-label exercises, not just Exercise 3.8.