### PR TITLE
Silence SCHEME title warnings and fix JVASCRIPTINLINE typo

### DIFF
--- a/javascript/parseXmlHtml.tsx
+++ b/javascript/parseXmlHtml.tsx
@@ -47,6 +47,7 @@ export const tagsToRemove = new Set([
   "EXCLUDE",
   "HISTORY",
   "ORDER",
+  "SCHEME",
   "SOLUTION",
   "INDEX",
   "CAPTION",

--- a/xml/chapter5/section1/section1.xml
+++ b/xml/chapter5/section1/section1.xml
@@ -208,7 +208,7 @@ function factorial(n) {
       <JAVASCRIPTINLINE>iter(product, counter)</JAVASCRIPTINLINE> is seeded by the
       arguments <JAVASCRIPTINLINE>(1, 1)</JAVASCRIPTINLINE> and runs until
       <JAVASCRIPTINLINE>counter > n</JAVASCRIPTINLINE>, at which point the product is
-      returned. Unlike <JVASCRIPTINLINE>gcd(a, b)</JVASCRIPTINLINE>, the register
+      returned. Unlike <JAVASCRIPTINLINE>gcd(a, b)</JAVASCRIPTINLINE>, the register
       machine has no need of a temporary register assuming that the correct order of
       register assignment is followed.
 


### PR DESCRIPTION
Clears all `WARNING Unrecognised Tag` output from the build (28 → 0), which came from two distinct causes.

## 1. SCHEME title warnings (cosmetic, ~26 of them)
Bilingual section titles are written as:
```xml
<NAME>Evaluating <SPLITINLINE><SCHEME>Combinations</SCHEME><JAVASCRIPT>Operator Combinations</JAVASCRIPT></SPLITINLINE></NAME>
```
During the "generate table of content" pass, the title is run through the **HTML** text processor (`recursiveProcessTextHtml`). Unlike the JSON processor, `parseXmlHtml.tsx` did **not** list `SCHEME` in `tagsToRemove`, so every `<SCHEME>` title alternative fell through to the "Unrecognised Tag" fallback and warned. The JS title rendered correctly (the Scheme text was dropped anyway) — it was pure log noise.

**Fix:** add `"SCHEME"` to `tagsToRemove` in `parseXmlHtml.tsx`, matching the JSON processor. The parallel "show both languages" display uses a separate handler map (`processTextFunctionsSplit`) and is unaffected.

## 2. `JVASCRIPTINLINE` typo (real content bug)
`xml/chapter5/section1/section1.xml:211` had `<JVASCRIPTINLINE>gcd(a, b)</JVASCRIPTINLINE>` — misspelled `JAVASCRIPTINLINE` (missing the first `A`), so that inline code wasn't rendered as code in chapter 5.1. Fixed the tag name.

## Verification
- `yarn json` completes (exit 0) and now reports **0** `Unrecognised Tag` warnings (was 28).
- Bilingual titles still render the JavaScript variant only — e.g. `1.1.3` is "Evaluating … Operator Combinations", not "Combinations" — with no Scheme text leaking in (checked for `ProceduresFunctions`/`CombinationsOperator` concatenations; none).