### PR TITLE
Fix 'Repeated REF name' warnings (PDF_ONLY duplicates + ex:5_29 collision)

### DIFF
--- a/javascript/processingFunctions/processReferenceHtml.js
+++ b/javascript/processingFunctions/processReferenceHtml.js
@@ -50,6 +50,12 @@ export const setupReferences = (node, filename) => {
     const ref_type = referenceName.split(":")[0];
     //const ref_name = referenceName.split(":")[1];
 
+    if (ancestorHasTag(label, "PDF_ONLY")) {
+      // PDF-only duplicates (figures repeated in a PDF_ONLY block for
+      // pagination) are not part of the web edition.
+      continue;
+    }
+
     if (referenceStore[referenceName]) {
       console.log(chapterIndex);
       repeatedRefNameWarning(referenceName);

--- a/javascript/processingFunctions/processReferenceJson.js
+++ b/javascript/processingFunctions/processReferenceJson.js
@@ -50,6 +50,14 @@ export const setupReferencesJson = (node, filename) => {
     const referenceName = label.getAttribute("NAME");
     const ref_type = referenceName.split(":")[0];
 
+    // Skip SCHEME labels and PDF-only duplicates (figures repeated in a
+    // PDF_ONLY block for pagination) before the duplicate check: the PDF
+    // copy may appear after the web copy has already been registered, so
+    // checking after the duplicate test would still warn.
+    if (ancestorHasTag(label, "SCHEME") || ancestorHasTag(label, "PDF_ONLY")) {
+      continue;
+    }
+
     if (referenceStore[referenceName]) {
       console.log(chapterIndex);
       repeatedRefNameWarning(referenceName);
@@ -58,9 +66,7 @@ export const setupReferencesJson = (node, filename) => {
 
     let href;
     let displayName;
-    if (ancestorHasTag(label, "SCHEME")) {
-      continue;
-    } else if (ref_type == "chap") {
+    if (ref_type == "chap") {
       displayName = chapterIndex;
       href = `/sicpjs/${chapterIndex}`;
     } else if (ref_type == "sec") {

--- a/xml/chapter2/section5/subsection3.xml
+++ b/xml/chapter2/section5/subsection3.xml
@@ -1059,7 +1059,7 @@ function sub_poly(p1, p2) {
   </EXERCISE>
 
   <EXERCISE>
-    <LABEL NAME="ex:5_29"/>
+    <LABEL NAME="ex:2_89"/>
     <SPLITINLINE>
       <SCHEME>Define procedures</SCHEME>
       <JAVASCRIPT>Declare functions</JAVASCRIPT>


### PR DESCRIPTION
Clears all 14 `WARNING, Repeated REF name` messages from the build. Two distinct causes.

## 1. PDF_ONLY/WEB_ONLY figure duplicates (12 of 14)
Several figures are intentionally duplicated across `<WEB_ONLY>` and `<PDF_ONLY>` blocks for SICP-JS pagination (the figure is placed at a different spot in the web vs PDF layout), and both copies carry the same `<LABEL>`. The reference setup registered labels inside `PDF_ONLY` blocks — which the web/JSON edition otherwise removes — so each duplicated figure label got registered twice and warned.

**Fix:** skip `PDF_ONLY`-ancestor labels (alongside the existing `SCHEME` skip), in both `processReferenceJson.js` and `processReferenceHtml.js`.

A subtlety worth noting: the skip must run **before** the duplicate check. The existing `SCHEME` skip sat *after* it, which was fine because Scheme/JS labels have different names — but for same-named PDF/web duplicates, when the PDF copy appears *after* the web copy, the duplicate check would fire first. Moving the skip ahead of the duplicate check fixes it regardless of order. (This also corrects the href for figures where the PDF copy came first and was previously the one registered — it now resolves to the web copy.)

## 2. `ex:5_29` label collision (the remaining 2)
A genuine mislabel: a **chapter-2** exercise ("implement the term-list representation … for dense polynomials" — Exercise **2.89**) was labeled `ex:5_29`, colliding with Exercise 5.29 in chapter 5. Relabeled it `ex:2_89` — which is unused, unreferenced, and positionally correct (immediately before `ex:2_90`).

## Verification
- `yarn json` completes (exit 0) and reports **0** `Repeated REF name` warnings (was 14).
- No new `REF not found` warnings — all figure references still resolve. (The 5 remaining `ex:order-of-evaluation` warnings are pre-existing and fixed by the separate open PR #1197.)