### PR TITLE
Update outdated 'Show Dependencies' UI description in 1.1.2

### DIFF
--- a/xml/chapter1/section1/subsection2.xml
+++ b/xml/chapter1/section1/subsection2.xml
@@ -129,8 +129,7 @@ size;
           in an expression. In this online book, the statements that need to be
           evaluated before a new statement are omitted for brevity. However,
 	  to see and play with the program, you can click on it. The
-	  program then appears in a new
-	  browser tab, with the option <QUOTE>Show Dependencies</QUOTE>.
+	  program then appears inline with all dependencies included.
 	  Thus, as a result of clicking on
           <SNIPPET>
             <REQUIRES>var_size</REQUIRES>
@@ -138,8 +137,7 @@ size;
 5 * size;
             </JAVASCRIPT>
           </SNIPPET>
-          a new tab appears that contains the program, and after clicking
-	   <QUOTE>Show Dependencies</QUOTE>, you see:
+          you see:
           <SNIPPET>
 	    <EXPECTED>10</EXPECTED>
             <JAVASCRIPT>

--- a/xml/chapter3/section1/subsection1.xml
+++ b/xml/chapter3/section1/subsection1.xml
@@ -1517,6 +1517,7 @@ function make_account(balance, p) {
     function dispatch(m, q) {
         if (invalid_attempts &lt; 7) {
             if (p === q) {
+                invalid_attempts = 0; // reset after a correct password
                 return m === "withdraw"
                        ? withdraw
                        : m === "deposit"

--- a/xml/chapter3/section1/subsection1.xml
+++ b/xml/chapter3/section1/subsection1.xml
@@ -1515,23 +1515,25 @@ function make_account(balance, p) {
     }
 
     function dispatch(m, q) {
-        if (invalid_attempts &lt; 7) {
-            if (p === q) {
-                invalid_attempts = 0; // reset after a correct password
-                return m === "withdraw"
-                       ? withdraw
-                       : m === "deposit"
-                       ? deposit
-                       : "Unknown request: make_account";
+        if (invalid_attempts > 7) {
+            return calling_the_cops;
+        } else if (p === q) {
+            invalid_attempts = 0; // reset after a correct password
+            return m === "withdraw"
+                   ? withdraw
+                   : m === "deposit"
+                   ? deposit
+                   : "Unknown request: make_account";
+        } else {
+            invalid_attempts = invalid_attempts + 1;
+            if (invalid_attempts > 7) {
+                return calling_the_cops;
             } else {
-                invalid_attempts = invalid_attempts + 1;
                 return x => "Incorrect Password";
             }
-        } else {
-            return calling_the_cops;
         }
     }
-
+    
     return dispatch;
 
 }


### PR DESCRIPTION
Fixes the outdated UI description reported in #1070.

The passage in section 1.1.2 told readers that clicking a snippet opens it "in a new browser tab, with the option 'Show Dependencies'." Both statements are no longer true: the program now appears inline in the text, with dependencies already included — there is no separate tab and no "Show Dependencies" element.

The fix removes those two stale UI references and simplifies the surrounding sentence. The code snippets themselves (`5 * size;` and the full `const size = 2; 5 * size;`) are unchanged.

Closes #1070