### PR TITLE
Update outdated 'Show Dependencies' UI description in 1.1.2

### DIFF
--- a/xml/chapter1/section1/subsection2.xml
+++ b/xml/chapter1/section1/subsection2.xml
@@ -129,8 +129,7 @@ size;
           in an expression. In this online book, the statements that need to be
           evaluated before a new statement are omitted for brevity. However,
 	  to see and play with the program, you can click on it. The
-	  program then appears in a new
-	  browser tab, with the option <QUOTE>Show Dependencies</QUOTE>.
+	  program then appears inline with all dependencies included.
 	  Thus, as a result of clicking on
           <SNIPPET>
             <REQUIRES>var_size</REQUIRES>
@@ -138,8 +137,7 @@ size;
 5 * size;
             </JAVASCRIPT>
           </SNIPPET>
-          a new tab appears that contains the program, and after clicking
-	   <QUOTE>Show Dependencies</QUOTE>, you see:
+          you see:
           <SNIPPET>
 	    <EXPECTED>10</EXPECTED>
             <JAVASCRIPT>


### PR DESCRIPTION
The passage in section 1.1.2 told readers that clicking a snippet opens it "in a new browser tab, with the option 'Show Dependencies'." Both statements are no longer true: the program now appears inline in the text, with dependencies already included — there is no separate tab and no "Show Dependencies" element.

Removes both stale UI references and simplifies the surrounding sentence. Code snippets unchanged.

Closes #1070