### PR TITLE
Fix Exercise 3.57: add memoized fibs as required condition

### DIFF
--- a/xml/chapter3/section5/subsection2.xml
+++ b/xml/chapter3/section5/subsection2.xml
@@ -1119,10 +1119,20 @@ const S = pair(1, () => merge(scale_stream(S, 2),
 	<SCHEMEINLINE>fibs</SCHEMEINLINE> based on the
 	<JAVASCRIPTINLINE>add_streams</JAVASCRIPTINLINE> function?
 	Show that this number is exponentially greater than the number
-	of additions performed if 
+	of additions performed if
 	<JAVASCRIPTINLINE>add_streams</JAVASCRIPTINLINE> had used the function
 	<JAVASCRIPTINLINE>stream_map_2_optimized</JAVASCRIPTINLINE>
-	described in exercise<SPACE/><REF NAME="ex:combine-streams"/>.<FOOTNOTE>This
+	described in exercise<SPACE/><REF NAME="ex:combine-streams"/>,
+	and if we had declared <JAVASCRIPTINLINE>fibs</JAVASCRIPTINLINE> as
+	<SNIPPET EVAL="no">
+	  <JAVASCRIPT>
+const fibs = pair(0,
+                  memo(() => pair(1,
+                                  memo(() => add_streams(stream_tail(fibs),
+                                                         fibs)))));
+	  </JAVASCRIPT>
+	</SNIPPET>
+	<FOOTNOTE>This
 	exercise shows how call-by-need is closely related to
 	<INDEX>delayed expression<SUBINDEX>memoized</SUBINDEX></INDEX>
 	<INDEX>call-by-need argument passing<SUBINDEX>memoization and</SUBINDEX></INDEX>

--- a/xml/chapter3/section5/subsection2.xml
+++ b/xml/chapter3/section5/subsection2.xml
@@ -1132,16 +1132,6 @@ const fibs = pair(0,
                                                          fibs)))));
 	  </JAVASCRIPT>
 	</SNIPPET>
-	<FOOTNOTE>This
-	exercise shows how call-by-need is closely related to
-	<INDEX>delayed expression<SUBINDEX>memoized</SUBINDEX></INDEX>
-	<INDEX>call-by-need argument passing<SUBINDEX>memoization and</SUBINDEX></INDEX>
-	<INDEX>memoization<SUBINDEX>call-by-need and</SUBINDEX></INDEX>
-	ordinary memoization as described in
-	exercise<SPACE/><REF NAME="ex:memoization"/>. In that exercise, we used
-	assignment to explicitly construct a local table.  Our call-by-need stream
-	optimization effectively constructs such a table automatically, storing
-	values in the previously forced parts of the stream.</FOOTNOTE>
       </JAVASCRIPT>
     </SPLITINLINE>
   </EXERCISE>


### PR DESCRIPTION
Fixes the incorrect exercise question reported in #1063.

## Problem
Exercise 3.57 asked students to show that using `stream_map_2_optimized` in `add_streams` reduces the number of additions from exponential to linear. This is incorrect: the definition of `fibs` itself constructs two un-memoized tail thunks, so the exponential recomputation persists regardless of how `add_streams` is implemented. The `stream_map_2_optimized` memoization is never invoked for the recursive `fibs` calls.

## Fix
Following the maintainer's resolution in the issue thread, the exercise now adds a second condition — that `fibs` itself be declared with explicit `memo` calls on both tails:

```js
const fibs = pair(0,
                  memo(() => pair(1,
                                  memo(() => add_streams(stream_tail(fibs),
                                                         fibs)))));
```

Only with both conditions (memoized `add_streams` via `stream_map_2_optimized` *and* the memoized `fibs` declaration) does the number of additions become linear. The snippet is `EVAL="no"` since it references `add_streams` and `memo` from surrounding context.

The Scheme variant of the exercise is unaffected — it correctly relies on `cons-stream` baking in memoization.

Closes #1063