### PR TITLE
Fix punctuation in exercise 3.57: 'as' -> 'as follows:' before snippet

### DIFF
--- a/xml/chapter3/section5/subsection2.xml
+++ b/xml/chapter3/section5/subsection2.xml
@@ -1123,7 +1123,7 @@ const S = pair(1, () => merge(scale_stream(S, 2),
 	<JAVASCRIPTINLINE>add_streams</JAVASCRIPTINLINE> had used the function
 	<JAVASCRIPTINLINE>stream_map_2_optimized</JAVASCRIPTINLINE>
 	described in exercise<SPACE/><REF NAME="ex:combine-streams"/>,
-	and if we had declared <JAVASCRIPTINLINE>fibs</JAVASCRIPTINLINE> as
+	and if we had declared <JAVASCRIPTINLINE>fibs</JAVASCRIPTINLINE> as follows:
 	<SNIPPET EVAL="no">
 	  <JAVASCRIPT>
 const fibs = pair(0,


### PR DESCRIPTION
The introductory clause before the code snippet was left dangling with just 'as'. Changed to 'as follows:' so the sentence properly introduces the snippet.