### PR TITLE
Exclude <kbd> from MathJax processing in comparison edition

### DIFF
--- a/javascript/html/LinksHead.tsx
+++ b/javascript/html/LinksHead.tsx
@@ -92,7 +92,8 @@ const HtmlHeadPart2: FC<HtmlHeadPart2Props> = ({ toIndexFolder }) => {
         tex2jax: {
           inlineMath: [ ['$','$'], ["\\\\(","\\\\)"] ],
           processEscapes: true,
-          jax: ["input/TeX","output/HTML-CSS"]
+          jax: ["input/TeX","output/HTML-CSS"],
+          skipTags: ["kbd", "script", "noscript", "style", "textarea", "pre", "code"]
         }
       });
     </script>


### PR DESCRIPTION
Fixes the MathJax rendering issue reported in #904.

## Problem
Section 4.4 uses `$foo` syntax for logic programming pattern variables in the JS adaptation. In the comparison edition, inline JS code is rendered inside `<kbd>` tags (from `JAVASCRIPTINLINE`). However, MathJax was configured with `$...$` as inline math delimiters and scanned the entire page — including `<kbd>` content — treating `$pattern_variable` as math mode. This caused:
- The `$` signs to disappear
- Text to be italicised as math
- Underscores (e.g. in `$lives_near`) to produce subscripts

## Fix
Add `"kbd"` to MathJax's `skipTags` list in `LinksHead.tsx`. MathJax already supports this option for exactly this use case.

```js
skipTags: ["kbd", "script", "noscript", "style", "textarea", "pre", "code"]
```

The intentional `$...$` LaTeX in running text (from `<LATEXINLINE>`) renders as `\(...\)` or display math and appears outside `<kbd>`, so it is unaffected by this change.

This only affects the comparison edition (sicp.sourceacademy.org). The JS-only edition (sourceacademy.org/sicpjs) already works correctly as noted in the issue.

Closes #904