### PR TITLE
Clarify ex 1.25 solution: floating point overflow doesn't preserve remainders

### DIFF
--- a/xml/chapter1/section2/subsection6.xml
+++ b/xml/chapter1/section2/subsection6.xml
@@ -1022,8 +1022,8 @@ function expmod(base, exp, m) {
       floating point overflow does not preserve remainders. This is
       precisely why the original
       <JAVASCRIPTINLINE>expmod</JAVASCRIPTINLINE> avoids the problem by
-      keeping intermediate results small — never larger than
-      <LATEXINLINE>$m^2$</LATEXINLINE> — by taking the remainder at
+      keeping intermediate results small<EMDASH/>never larger than
+      <LATEXINLINE>$m^2$</LATEXINLINE><EMDASH/>by taking the remainder at
       each step.
       <P/>
       For small bases, however, Alyssa's method may be even faster than

--- a/xml/chapter1/section2/subsection6.xml
+++ b/xml/chapter1/section2/subsection6.xml
@@ -1017,7 +1017,14 @@ function expmod(base, exp, m) {
       any longer in this standard, the results become unreliable. Even
       worse, the method might exceed the largest number that can be
       represented in this standard, and the computation leads to an
-      error.
+      error. Note that unlike two's complement integer arithmetic, where
+      overflow wraps around and modular remainders are preserved,
+      floating point overflow does not preserve remainders. This is
+      precisely why the original
+      <JAVASCRIPTINLINE>expmod</JAVASCRIPTINLINE> avoids the problem by
+      keeping intermediate results small — never larger than
+      <LATEXINLINE>$m^2$</LATEXINLINE> — by taking the remainder at
+      each step.
       <P/>
       For small bases, however, Alyssa's method may be even faster than
       the original <JAVASCRIPTINLINE>expmod</JAVASCRIPTINLINE> function,


### PR DESCRIPTION
Improves the solution to Exercise 1.25 (§1.2.6), as discussed in #895.

The existing solution noted that large numbers become unreliable under IEEE 754, but left implicit the key point: unlike two's complement integer arithmetic (where overflow wraps and modular remainders are preserved), floating point overflow does **not** preserve remainders. This is precisely why Alyssa's approach fails for the Fermat test even when it doesn't outright error.

The added sentences make this explicit and connect it back to why the original `expmod` is designed to keep all intermediate values below $m^2$ by taking the remainder at each step.

Closes #895