### PR TITLE
Fix mathematical error in ex 1.25 solution (overflow and remainders)

### DIFF
--- a/xml/chapter1/section2/subsection6.xml
+++ b/xml/chapter1/section2/subsection6.xml
@@ -1017,9 +1017,8 @@ function expmod(base, exp, m) {
       any longer in this standard, the results become unreliable. Even
       worse, the method might exceed the largest number that can be
       represented in this standard, and the computation leads to an
-      error. Note that unlike two's complement integer arithmetic, where
-      overflow wraps around and modular remainders are preserved,
-      floating point overflow does not preserve remainders. This is
+      error. Note that even with integer arithmetic, overflow does not
+      preserve remainders modulo <LATEXINLINE>$m$</LATEXINLINE>. This is
       precisely why the original
       <JAVASCRIPTINLINE>expmod</JAVASCRIPTINLINE> avoids the problem by
       keeping intermediate results small<EMDASH/>never larger than


### PR DESCRIPTION
Fixes a mathematical error introduced in PR #1207 (caught by the Gemini review).

The added text claimed: *"unlike two's complement integer arithmetic, where overflow wraps around and modular remainders are preserved"*. This is incorrect: two's complement overflow only preserves remainders when $m$ divides $2^w$ (i.e. $m$ is a power of 2). For an arbitrary modulus — as used in the Fermat test — overflow does not preserve remainders even with integer arithmetic.

Replaces the incorrect claim with the simpler, correct formulation suggested in the Gemini review: *"even with integer arithmetic, overflow does not preserve remainders modulo $m$"*.