### PR TITLE
Move jax to top-level MathJax config (was incorrectly nested in tex2jax)

### DIFF
--- a/javascript/html/LinksHead.tsx
+++ b/javascript/html/LinksHead.tsx
@@ -89,10 +89,10 @@ const HtmlHeadPart2: FC<HtmlHeadPart2Props> = ({ toIndexFolder }) => {
     <!-- Rendering inline LaTeX -->
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({
+        jax: ["input/TeX","output/HTML-CSS"],
         tex2jax: {
           inlineMath: [ ['$','$'], ["\\\\(","\\\\)"] ],
           processEscapes: true,
-          jax: ["input/TeX","output/HTML-CSS"],
           skipTags: ["kbd", "script", "noscript", "style", "textarea", "pre", "code"]
         }
       });


### PR DESCRIPTION
Fixes a pre-existing misconfiguration caught by the Gemini review of PR #1206.

In MathJax 2.x, `jax` is a top-level `Hub.Config` option that specifies which input/output jax to load. It was placed inside the `tex2jax` preprocessor block where MathJax ignores it (falling back to defaults or URL-configured values). Moved to the top level where it belongs. `skipTags` correctly stays inside `tex2jax`.