### PR TITLE
Remove redundant jax from MathJax config

### DIFF
--- a/javascript/html/LinksHead.tsx
+++ b/javascript/html/LinksHead.tsx
@@ -89,7 +89,6 @@ const HtmlHeadPart2: FC<HtmlHeadPart2Props> = ({ toIndexFolder }) => {
     <!-- Rendering inline LaTeX -->
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({
-        jax: ["input/TeX","output/HTML-CSS"],
         tex2jax: {
           inlineMath: [ ['$','$'], ["\\\\(","\\\\)"] ],
           processEscapes: true,


### PR DESCRIPTION
The loaded config file `TeX-AMS-MML_HTMLorMML-full` already configures all appropriate jax (input/TeX, input/MathML, output/HTML-CSS, output/NativeMML, output/SVG). Manually specifying `jax` overrides those defaults, disabling SVG and NativeMML fallbacks that improve accessibility and performance on supported browsers. Suggested in the Gemini review of PR #1209.