### PR TITLE
Document Unix requirement for PDF/full build in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Available versions:
 
 Details how to generate these versions are in the [repo wiki](https://github.com/source-academy/sicp/wiki).
 
+**Platform requirement:** Generating the JSON and HTML editions (`yarn json`, `yarn js`) works on any platform with Node.js. Generating the PDF edition and running the full build require Unix/macOS; Windows users can use [WSL](https://learn.microsoft.com/en-us/windows/wsl/) to run the shell scripts involved.
+
 Check out our [Resources for Learners, Educators and Researchers](https://about.sourceacademy.org/), and read more [About the SICP JS Project](https://sourceacademy.org/sicpjs/making-of) in Interactive SICP JS.
 
 ## Licenses


### PR DESCRIPTION
Adds a platform requirement note to the README, addressing #886.

`yarn json` and `yarn js` (the JSON and HTML editions) work cross-platform with Node.js. The PDF and full builds call `.sh` scripts (`do.sh`, `svg_to_pdf.sh`, `nodetest.sh`) that require Unix/macOS; Windows users are pointed to WSL.

Closes #886