### PR TITLE
Fix index: use 'prime sieve' instead of 'sieve of Eratosthenes' on sieve snippet

### DIFF
--- a/xml/chapter3/section5/subsection2.xml
+++ b/xml/chapter3/section5/subsection2.xml
@@ -275,7 +275,7 @@ stream_ref(primes, 50);
     </SNIPPET>
     <SNIPPET EVAL="yes">
       <INDEX><DECLARATION>primes</DECLARATION> (infinite stream)</INDEX>
-      <INDEX>sieve of Eratosthenes<SUBINDEX><DECLARATION>sieve</DECLARATION></SUBINDEX></INDEX>
+      <INDEX>prime sieve<SUBINDEX><DECLARATION>sieve</DECLARATION></SUBINDEX></INDEX>
       <NAME>sieve</NAME>
       <REQUIRES>is_divisible2</REQUIRES>
       <REQUIRES>integers_starting_from</REQUIRES>

--- a/xml/chapter3/section5/subsection2.xml
+++ b/xml/chapter3/section5/subsection2.xml
@@ -248,7 +248,7 @@ const fibs = fibgen(0, 1);
     O<APOS/>Neill shows in <CITATION>O<APOS/>Neill 2009</CITATION>, it tests
     each candidate for divisibility by the primes found so far<EMDASH/>a form of
     <EM>trial division</EM><EMDASH/>rather than crossing off multiples, and is
-    substantially less efficient than the genuine sieve.</FOOTNOTE>
+    substantially less efficient than the sieve of Eratosthenes.</FOOTNOTE>
     We start with the integers beginning with 2, which is the first prime.
     To get the rest of the primes, we start by filtering the multiples of
     2 from the rest of the integers.  This leaves a stream beginning with


### PR DESCRIPTION
Follow-up to PR #1187.

The `sieve` snippet in 3.5.2 had an index entry attributing it to the Sieve of Eratosthenes — inconsistent with the body text change in #1187, which now calls the method a "sieving method" and explains in a footnote that it is actually trial division, not Eratosthenes's sieve.

Replace the index entry on the snippet with the generic **`prime sieve > sieve`**, which correctly describes the function without the incorrect attribution.

The `sieve of Eratosthenes` and `Eratosthenes` index entries remain inside the footnote, where they are discussed and where they correctly belong.