### PR TITLE
Refactor (no-op): route build paths through an edition descriptor

### DIFF
--- a/javascript/editions.ts
+++ b/javascript/editions.ts
@@ -1,0 +1,52 @@
+// Edition / language descriptors.
+//
+// SICP JS is generated from XML sources in which the non-Scheme language is
+// tagged with <JAVASCRIPT...>. To support a parallel edition that uses a
+// different language (e.g. Python, tagged <PYTHON...> in xml_py/), the parts
+// of the build that are specific to that language are collected here behind a
+// descriptor, instead of being hardcoded throughout the pipeline.
+//
+// This module currently defines only the JavaScript edition, and the build
+// selects it by default, so existing output is unchanged. The Python edition
+// descriptor will be added here once the parsers consume the `language` tags.
+
+// The XML tag names that carry the non-Scheme language's code.
+export type LanguageDescriptor = {
+  key: string; // short identifier, also used in output naming, e.g. "js"
+  blockTag: string; // code block, e.g. "JAVASCRIPT"
+  inlineTag: string; // inline code, e.g. "JAVASCRIPTINLINE"
+  runTag: string; // "JAVASCRIPT_RUN"
+  testTag: string; // "JAVASCRIPT_TEST"
+  outputTag: string; // "JAVASCRIPT_OUTPUT"
+  promptTag: string; // "JAVASCRIPT_PROMPT"
+};
+
+export const javascriptLanguage: LanguageDescriptor = {
+  key: "js",
+  blockTag: "JAVASCRIPT",
+  inlineTag: "JAVASCRIPTINLINE",
+  runTag: "JAVASCRIPT_RUN",
+  testTag: "JAVASCRIPT_TEST",
+  outputTag: "JAVASCRIPT_OUTPUT",
+  promptTag: "JAVASCRIPT_PROMPT"
+};
+
+// An edition ties a language to its source tree and output naming.
+export type Edition = {
+  language: LanguageDescriptor;
+  inputDirName: string; // source tree relative to repo root, e.g. "xml"
+  outputSuffix: string; // appended to output dir names, e.g. "" or "_py"
+};
+
+export const javascriptEdition: Edition = {
+  language: javascriptLanguage,
+  inputDirName: "xml",
+  outputSuffix: ""
+};
+
+// Selects the edition to build. Defaults to the JavaScript edition so that
+// existing builds are byte-for-byte unchanged. A Python edition will be
+// selectable here (e.g. via an environment variable) in a later step.
+export function getEdition(): Edition {
+  return javascriptEdition;
+}

--- a/javascript/editions.ts
+++ b/javascript/editions.ts
@@ -12,13 +12,13 @@
 
 // The XML tag names that carry the non-Scheme language's code.
 export type LanguageDescriptor = {
-  key: string; // short identifier, also used in output naming, e.g. "js"
-  blockTag: string; // code block, e.g. "JAVASCRIPT"
-  inlineTag: string; // inline code, e.g. "JAVASCRIPTINLINE"
-  runTag: string; // "JAVASCRIPT_RUN"
-  testTag: string; // "JAVASCRIPT_TEST"
-  outputTag: string; // "JAVASCRIPT_OUTPUT"
-  promptTag: string; // "JAVASCRIPT_PROMPT"
+  readonly key: string; // short identifier, also used in output naming, e.g. "js"
+  readonly blockTag: string; // code block, e.g. "JAVASCRIPT"
+  readonly inlineTag: string; // inline code, e.g. "JAVASCRIPTINLINE"
+  readonly runTag: string; // "JAVASCRIPT_RUN"
+  readonly testTag: string; // "JAVASCRIPT_TEST"
+  readonly outputTag: string; // "JAVASCRIPT_OUTPUT"
+  readonly promptTag: string; // "JAVASCRIPT_PROMPT"
 };
 
 export const javascriptLanguage: LanguageDescriptor = {
@@ -33,9 +33,9 @@ export const javascriptLanguage: LanguageDescriptor = {
 
 // An edition ties a language to its source tree and output naming.
 export type Edition = {
-  language: LanguageDescriptor;
-  inputDirName: string; // source tree relative to repo root, e.g. "xml"
-  outputSuffix: string; // appended to output dir names, e.g. "" or "_py"
+  readonly language: LanguageDescriptor;
+  readonly inputDirName: string; // source tree relative to repo root, e.g. "xml"
+  readonly outputSuffix: string; // appended to output dir names, e.g. "" or "_py"
 };
 
 export const javascriptEdition: Edition = {

--- a/javascript/index.ts
+++ b/javascript/index.ts
@@ -268,9 +268,17 @@ async function main() {
     version = process.argv[3];
 
     if (version == "split") {
-      outputDir = path.join(__dirname, "..", "html_split" + edition.outputSuffix);
+      outputDir = path.join(
+        __dirname,
+        "..",
+        "html_split" + edition.outputSuffix
+      );
     } else if (version == "scheme") {
-      outputDir = path.join(__dirname, "..", "html_scheme" + edition.outputSuffix);
+      outputDir = path.join(
+        __dirname,
+        "..",
+        "html_scheme" + edition.outputSuffix
+      );
     }
 
     switchParseFunctionsHtml(version);
@@ -292,7 +300,11 @@ async function main() {
 
     recursiveXmlToHtmlInOrder("parseXml");
   } else if (parseType == "js") {
-    outputDir = path.join(__dirname, "..", "js_programs" + edition.outputSuffix);
+    outputDir = path.join(
+      __dirname,
+      "..",
+      "js_programs" + edition.outputSuffix
+    );
 
     createMain(inputDir, outputDir, parseType);
     console.log("setup snippets\n");

--- a/javascript/index.ts
+++ b/javascript/index.ts
@@ -37,14 +37,16 @@ import { setupSnippetsJson } from "./processingFunctions/processSnippetJson.js";
 import { createTocJson } from "./generateTocJson.js";
 import { setupReferencesJson } from "./processingFunctions/processReferenceJson.js";
 import { createMain } from "./commands/utils.js";
+import { getEdition } from "./editions.js";
 import type { WriteBuffer } from "./types.js";
 
 export let parseType;
 let version;
 let outputDir: string; // depends on parseType
 
+const edition = getEdition();
 const __dirname = path.resolve(import.meta.dirname);
-const inputDir = path.join(__dirname, "../xml");
+const inputDir = path.join(__dirname, "..", edition.inputDirName);
 
 const ensureDirectoryExists = (path, cb) => {
   fs.mkdir(path, err => {
@@ -242,7 +244,7 @@ const createIndexHtml = version => {
 async function main() {
   parseType = process.argv[2];
   if (parseType == "pdf") {
-    outputDir = path.join(__dirname, "../latex_pdf");
+    outputDir = path.join(__dirname, "../latex_pdf" + edition.outputSuffix);
 
     switchParseFunctionsLatex(parseType);
     createMain(inputDir, outputDir, parseType);
@@ -266,9 +268,9 @@ async function main() {
     version = process.argv[3];
 
     if (version == "split") {
-      outputDir = path.join(__dirname, "../html_split");
+      outputDir = path.join(__dirname, "../html_split" + edition.outputSuffix);
     } else if (version == "scheme") {
-      outputDir = path.join(__dirname, "../html_scheme");
+      outputDir = path.join(__dirname, "../html_scheme" + edition.outputSuffix);
     }
 
     switchParseFunctionsHtml(version);
@@ -290,7 +292,7 @@ async function main() {
 
     recursiveXmlToHtmlInOrder("parseXml");
   } else if (parseType == "js") {
-    outputDir = path.join(__dirname, "../js_programs");
+    outputDir = path.join(__dirname, "../js_programs" + edition.outputSuffix);
 
     createMain(inputDir, outputDir, parseType);
     console.log("setup snippets\n");
@@ -298,7 +300,7 @@ async function main() {
     console.log("setup snippets done\n");
     recursiveTranslateXml("", "parseXml");
   } else if (parseType == "json") {
-    outputDir = path.join(__dirname, "../json");
+    outputDir = path.join(__dirname, "../json" + edition.outputSuffix);
 
     createMain(inputDir, outputDir, parseType);
 

--- a/javascript/index.ts
+++ b/javascript/index.ts
@@ -244,7 +244,7 @@ const createIndexHtml = version => {
 async function main() {
   parseType = process.argv[2];
   if (parseType == "pdf") {
-    outputDir = path.join(__dirname, "../latex_pdf" + edition.outputSuffix);
+    outputDir = path.join(__dirname, "..", "latex_pdf" + edition.outputSuffix);
 
     switchParseFunctionsLatex(parseType);
     createMain(inputDir, outputDir, parseType);
@@ -268,9 +268,9 @@ async function main() {
     version = process.argv[3];
 
     if (version == "split") {
-      outputDir = path.join(__dirname, "../html_split" + edition.outputSuffix);
+      outputDir = path.join(__dirname, "..", "html_split" + edition.outputSuffix);
     } else if (version == "scheme") {
-      outputDir = path.join(__dirname, "../html_scheme" + edition.outputSuffix);
+      outputDir = path.join(__dirname, "..", "html_scheme" + edition.outputSuffix);
     }
 
     switchParseFunctionsHtml(version);
@@ -292,7 +292,7 @@ async function main() {
 
     recursiveXmlToHtmlInOrder("parseXml");
   } else if (parseType == "js") {
-    outputDir = path.join(__dirname, "../js_programs" + edition.outputSuffix);
+    outputDir = path.join(__dirname, "..", "js_programs" + edition.outputSuffix);
 
     createMain(inputDir, outputDir, parseType);
     console.log("setup snippets\n");
@@ -300,7 +300,7 @@ async function main() {
     console.log("setup snippets done\n");
     recursiveTranslateXml("", "parseXml");
   } else if (parseType == "json") {
-    outputDir = path.join(__dirname, "../json" + edition.outputSuffix);
+    outputDir = path.join(__dirname, "..", "json" + edition.outputSuffix);
 
     createMain(inputDir, outputDir, parseType);
 


### PR DESCRIPTION
First step of a staged refactor to generalize the build's "language axis" so it can produce a Python edition (from `xml_py/`) alongside the JavaScript edition, sharing one tooling codebase.

## What this does
- Adds `javascript/editions.ts` defining:
  - `LanguageDescriptor` — the XML tag names that carry the non-Scheme language's code (`JAVASCRIPT`, `JAVASCRIPTINLINE`, `JAVASCRIPT_RUN/_TEST/_OUTPUT/_PROMPT`).
  - `Edition` — ties a language to its source tree (`inputDirName`) and output naming (`outputSuffix`).
  - `getEdition()` — returns the JavaScript edition by default.
- `index.ts` now derives the input directory and the five output-dir names from the edition, instead of hardcoding `xml` and the `latex_pdf`/`html_split`/`html_scheme`/`js_programs`/`json` literals.

## Why it's a no-op
With the default JavaScript edition (`inputDirName: "xml"`, `outputSuffix: ""`), every derived path is identical to before.

Verified:
- `yarn json` (deterministic build): output is **byte-for-byte identical** to master.
- `yarn js` (`js_programs`): **no content differences**. (The js build fires `recursiveTranslateXml` without `await` in `index.ts`, so which per-file directories get flushed varies between runs regardless of this change; two runs of this branch's code differ by 0.)
- No new `tsc` errors in the changed files.

## What's next (not in this PR)
The descriptor's **tag** fields aren't consumed yet. Subsequent PRs will thread them into the parsers (`parseXmlJson`, `parseXmlHtml`, `parseXmlJs`, `parseXmlLatex`, `processingFunctions/*`) to replace the hardcoded `"JAVASCRIPT"`/`"JAVASCRIPTINLINE"` literals, each verified byte-identical the same way. Then a Python edition descriptor can be added and selected.