### PR TITLE
Refactor (no-op): thread language descriptor through parseXmlJson

### DIFF
--- a/javascript/parseXmlJson.js
+++ b/javascript/parseXmlJson.js
@@ -21,6 +21,11 @@ import {
   parseAndInsertToIdToContentMap
 } from "./searchRewrite.js";
 
+import { getEdition } from "./editions.js";
+
+// Tag names of the edition's non-Scheme language (JAVASCRIPT* by default).
+const lang = getEdition().language;
+
 let paragraph_count = 0;
 let heading_count = 0;
 let footnote_count = 0;
@@ -73,7 +78,7 @@ const ignoreTags = new Set([
   "CHAPTERCONTENT",
   "SPLIT",
   "SPLITINLINE",
-  "JAVASCRIPT",
+  lang.blockTag,
   "CITATION",
   "SECTIONCONTENT",
   "p",
@@ -322,10 +327,9 @@ const processTextFunctions = {
     processReferenceJson(node, obj, chapterIndex);
   },
 
-  SCHEMEINLINE: (node, obj) =>
-    processTextFunctions["JAVASCRIPTINLINE"](node, obj),
+  SCHEMEINLINE: (node, obj) => processTextFunctions[lang.inlineTag](node, obj),
 
-  JAVASCRIPTINLINE: (node, obj) => {
+  [lang.inlineTag]: (node, obj) => {
     if (
       node.firstChild &&
       node.firstChild.data &&
@@ -341,7 +345,7 @@ const processTextFunctions = {
     });
 
     addArrayToObj(obj, node, writeTo);
-    obj["tag"] = "JAVASCRIPTINLINE";
+    obj["tag"] = lang.inlineTag;
   },
 
   SNIPPET: (node, obj) => {
@@ -356,19 +360,19 @@ const processTextFunctions = {
 
       const writeTo = [];
 
-      const textprompt = getChildrenByTagName(node, "JAVASCRIPT_PROMPT")[0];
+      const textprompt = getChildrenByTagName(node, lang.promptTag)[0];
       if (textprompt) {
         recursivelyProcessTextSnippetJson(textprompt.firstChild, writeTo);
       }
 
-      const textit = getChildrenByTagName(node, "JAVASCRIPT")[0];
+      const textit = getChildrenByTagName(node, lang.blockTag)[0];
       if (textit) {
         recursivelyProcessTextSnippetJson(textit.firstChild, writeTo);
       } else {
         recursivelyProcessTextSnippetJson(node.firstChild, writeTo);
       }
 
-      const textoutput = getChildrenByTagName(node, "JAVASCRIPT_OUTPUT")[0];
+      const textoutput = getChildrenByTagName(node, lang.outputTag)[0];
       if (textoutput) {
         recursivelyProcessTextSnippetJson(textoutput.firstChild, writeTo);
       }


### PR DESCRIPTION
Stage 2 of the language-axis refactor (follows #1214).

Replaces the hardcoded `JAVASCRIPT*` tag literals in `parseXmlJson.js` with the edition's `language` descriptor from `editions.ts`:
- `ignoreTags` entry `"JAVASCRIPT"` → `lang.blockTag`
- inline-code handler key `JAVASCRIPTINLINE:` → computed `[lang.inlineTag]:`, and its output `obj["tag"]` → `lang.inlineTag`
- `SCHEMEINLINE` delegation → `processTextFunctions[lang.inlineTag]`
- snippet lookups → `lang.promptTag` / `lang.blockTag` / `lang.outputTag`

## No-op
With the default JavaScript edition, every descriptor field equals the literal it replaced, so output is unchanged.

Verified:
- `yarn json` output is **byte-for-byte identical** to master (deterministic build, full `diff -rq`).
- `yarn lint` (prettier) clean; no new `tsc` errors.

The remaining `JAVASCRIPT` references in the json pipeline live in `processSnippetJson` and the other parsers (`parseXmlHtml`, `parseXmlJs`, `parseXmlLatex`) — those come in subsequent stages, each verified the same way.