### PR TITLE
Refactor (no-op): thread language descriptor through processSnippetJson

### DIFF
--- a/javascript/editions.ts
+++ b/javascript/editions.ts
@@ -10,15 +10,19 @@
 // selects it by default, so existing output is unchanged. The Python edition
 // descriptor will be added here once the parsers consume the `language` tags.
 
-// The XML tag names that carry the non-Scheme language's code.
+// Language-specific details of the edition's non-Scheme language.
 export type LanguageDescriptor = {
   readonly key: string; // short identifier, also used in output naming, e.g. "js"
+  // XML tag names that carry the language's code.
   readonly blockTag: string; // code block, e.g. "JAVASCRIPT"
   readonly inlineTag: string; // inline code, e.g. "JAVASCRIPTINLINE"
   readonly runTag: string; // "JAVASCRIPT_RUN"
   readonly testTag: string; // "JAVASCRIPT_TEST"
   readonly outputTag: string; // "JAVASCRIPT_OUTPUT"
   readonly promptTag: string; // "JAVASCRIPT_PROMPT"
+  // Surface strings emitted into generated output.
+  readonly commentPrefix: string; // line-comment marker, e.g. "//" (Python: "#")
+  readonly displayName: string; // edition name in headers, e.g. "SICP JS" (Python: "SICPy")
 };
 
 export const javascriptLanguage: LanguageDescriptor = {
@@ -28,8 +32,14 @@ export const javascriptLanguage: LanguageDescriptor = {
   runTag: "JAVASCRIPT_RUN",
   testTag: "JAVASCRIPT_TEST",
   outputTag: "JAVASCRIPT_OUTPUT",
-  promptTag: "JAVASCRIPT_PROMPT"
+  promptTag: "JAVASCRIPT_PROMPT",
+  commentPrefix: "//",
+  displayName: "SICP JS"
 };
+
+// The Python edition will add (in a later step):
+//   key: "py", blockTag: "PYTHON", inlineTag: "PYTHONINLINE", ...,
+//   commentPrefix: "#", displayName: "SICPy"
 
 // An edition ties a language to its source tree and output naming.
 export type Edition = {

--- a/javascript/processingFunctions/processSnippetJson.js
+++ b/javascript/processingFunctions/processSnippetJson.js
@@ -7,6 +7,10 @@ import {
 import { chapterIndex } from "../parseXmlJson";
 import recursiveProcessPureText from "./recursiveProcessPureText";
 import { processRuneModule } from "./processModuleImports.js";
+import { getEdition } from "../editions.js";
+
+// Tag names of the edition's non-Scheme language (JAVASCRIPT* by default).
+const lang = getEdition().language;
 
 const snippetStore = {};
 
@@ -14,8 +18,8 @@ export const setupSnippetsJson = node => {
   const snippets = node.getElementsByTagName("SNIPPET");
   for (let i = 0; snippets[i]; i++) {
     const snippet = snippets[i];
-    const jsSnippet = snippet.getElementsByTagName("JAVASCRIPT")[0];
-    let jsRunSnippet = snippet.getElementsByTagName("JAVASCRIPT_RUN")[0];
+    const jsSnippet = snippet.getElementsByTagName(lang.blockTag)[0];
+    let jsRunSnippet = snippet.getElementsByTagName(lang.runTag)[0];
     if (!jsRunSnippet) {
       jsRunSnippet = jsSnippet;
     }
@@ -77,7 +81,7 @@ export const recursivelyProcessTextSnippetJson = (node, writeTo) => {
     writeTo.push("$\\langle{}$");
     recursivelyProcessTextSnippetJson(node.firstChild, writeTo);
     writeTo.push("$\\rangle$");
-  } else if (name === "JAVASCRIPTINLINE") {
+  } else if (name === lang.inlineTag) {
     recursivelyProcessTextSnippetJson(node.firstChild, writeTo);
   } else if (name === "#comment" || name === "ALLOW_BREAK") {
     return;
@@ -97,18 +101,18 @@ export const processSnippetJson = (node, snippet) => {
 
   addToSnippet("eval", false, snippet);
 
-  const jsPromptSnippet = node.getElementsByTagName("JAVASCRIPT_PROMPT")[0];
+  const jsPromptSnippet = node.getElementsByTagName(lang.promptTag)[0];
 
   if (jsPromptSnippet) {
     addToSnippet("body", jsPromptSnippet.firstChild.nodeValue.trim(), snippet);
   }
 
-  const jsSnippet = node.getElementsByTagName("JAVASCRIPT")[0];
-  const jsOutputSnippet = node.getElementsByTagName("JAVASCRIPT_OUTPUT")[0];
+  const jsSnippet = node.getElementsByTagName(lang.blockTag)[0];
+  const jsOutputSnippet = node.getElementsByTagName(lang.outputTag)[0];
 
   if (jsSnippet) {
     // JavaScript source for running. Overrides JAVASCRIPT if present.
-    let jsRunSnippet = node.getElementsByTagName("JAVASCRIPT_RUN")[0];
+    let jsRunSnippet = node.getElementsByTagName(lang.runTag)[0];
     if (!jsRunSnippet) {
       jsRunSnippet = jsSnippet;
     }

--- a/javascript/processingFunctions/processSnippetJson.js
+++ b/javascript/processingFunctions/processSnippetJson.js
@@ -218,7 +218,10 @@ export const processSnippetJson = (node, snippet) => {
       }
 
       const compressed = lzString.compressToEncodedURIComponent(
-        "// SICP JS " +
+        lang.commentPrefix +
+          " " +
+          lang.displayName +
+          " " +
           chapterIndex +
           importStatement +
           reqStr +


### PR DESCRIPTION
Stage 3 of the language-axis refactor (follows #1214, #1216), completing the json snippet pipeline.

Replaces the hardcoded `JAVASCRIPT*` tag lookups in `processSnippetJson.js` with the edition's `language` descriptor: `setupSnippetsJson` and `processSnippetJson` now use `lang.blockTag` / `lang.runTag` / `lang.inlineTag` / `lang.promptTag` / `lang.outputTag`.

## No-op
With the default JavaScript edition every field equals the literal it replaced.

Verified:
- `yarn json` output **byte-for-byte identical** to master (full `diff -rq`).
- `yarn lint` (prettier) clean; no new `tsc` errors.

Independent of #1216 (both are no-op against master); can merge in either order. Next stages: the html/comparison (`parseXmlHtml` + its `processingFunctions`), `parseXmlJs`, and `parseXmlLatex`.