### PR TITLE
Refactor (no-op): thread language descriptor through parseXmlJs

### DIFF
--- a/javascript/parseXmlJs.js
+++ b/javascript/parseXmlJs.js
@@ -2,6 +2,10 @@ import path from "path";
 import fs from "fs";
 
 import { processSnippetJs } from "./processingFunctions/index.js";
+import { getEdition } from "./editions.js";
+
+// Tag names of the edition's non-Scheme language (JAVASCRIPT* by default).
+const lang = getEdition().language;
 
 let snippet_count = 0;
 let relativeFileDirectory = "";
@@ -24,7 +28,7 @@ const ignoreTags = new Set([
   "CHAPTERCONTENT",
   "span",
   "SPLITINLINE",
-  "JAVASCRIPT"
+  lang.blockTag
 ]);
 
 const preserveTags = new Set([


### PR DESCRIPTION
Stage 4 of the language-axis refactor (follows #1214, #1216, #1217).

Replaces the single hardcoded `"JAVASCRIPT"` entry in `parseXmlJs`'s `ignoreTags` with `lang.blockTag` from the edition descriptor.

## No-op
With the default JavaScript edition, `lang.blockTag === "JAVASCRIPT"`.

Verified: after saturating the (inherently racy, unawaited) `yarn js` build, `js_programs` has **no content differences** vs master (`diff -rq` reports 0). Prettier clean; no new `tsc` errors.

The snippet extraction itself lives in `processSnippetJs` (a separate stage). Remaining after that: `parseXmlHtml` (+ html `processingFunctions`) and `parseXmlLatex`.