### PR TITLE
Refactor (no-op): thread language descriptor through processSnippetJs

### DIFF
--- a/javascript/editions.ts
+++ b/javascript/editions.ts
@@ -23,6 +23,7 @@ export type LanguageDescriptor = {
   // Surface strings emitted into generated output.
   readonly commentPrefix: string; // line-comment marker, e.g. "//" (Python: "#")
   readonly displayName: string; // edition name in headers, e.g. "SICP JS" (Python: "SICPy")
+  readonly fileExtension: string; // extracted-program extension, e.g. ".js" (Python: ".py")
 };
 
 export const javascriptLanguage: LanguageDescriptor = {
@@ -34,12 +35,13 @@ export const javascriptLanguage: LanguageDescriptor = {
   outputTag: "JAVASCRIPT_OUTPUT",
   promptTag: "JAVASCRIPT_PROMPT",
   commentPrefix: "//",
-  displayName: "SICP JS"
+  displayName: "SICP JS",
+  fileExtension: ".js"
 };
 
 // The Python edition will add (in a later step):
 //   key: "py", blockTag: "PYTHON", inlineTag: "PYTHONINLINE", ...,
-//   commentPrefix: "#", displayName: "SICPy"
+//   commentPrefix: "#", displayName: "SICPy", fileExtension: ".py"
 
 // An edition ties a language to its source tree and output naming.
 export type Edition = {

--- a/javascript/parseXmlJs.js
+++ b/javascript/parseXmlJs.js
@@ -56,7 +56,7 @@ const processTextFunctions = {
 
     const snippet_count_string =
       snippet_count < 10 ? "0" + snippet_count : snippet_count;
-    processSnippetJs(node, writeTojs, "js");
+    processSnippetJs(node, writeTojs, lang.key);
 
     const nameNode = node.getElementsByTagName("NAME")[0];
 

--- a/javascript/parseXmlJs.js
+++ b/javascript/parseXmlJs.js
@@ -64,7 +64,10 @@ const processTextFunctions = {
       ? snippet_count_string + "_" + nameNode.firstChild.nodeValue
       : snippet_count_string;
 
-    const outputFile = path.join(relativeFileDirectory, fileName + `.js`);
+    const outputFile = path.join(
+      relativeFileDirectory,
+      fileName + lang.fileExtension
+    );
 
     const stream = fs.createWriteStream(outputFile);
     stream.once("open", fd => {

--- a/javascript/processingFunctions/processSnippetJs.js
+++ b/javascript/processingFunctions/processSnippetJs.js
@@ -142,7 +142,7 @@ export const processSnippetJs = (node, writeTo, fileFormat) => {
       );
     }
 
-    if (fileFormat == "js") {
+    if (fileFormat === lang.key) {
       writeTo.push(reqStr);
       writeTo.push(codeStr_run);
       writeTo.push(exampleStr);

--- a/javascript/processingFunctions/processSnippetJs.js
+++ b/javascript/processingFunctions/processSnippetJs.js
@@ -5,6 +5,10 @@ import {
 } from "./warnings.js";
 import recursiveProcessPureText from "./recursiveProcessPureText";
 import { processRuneModule } from "./processModuleImports.js";
+import { getEdition } from "../editions.js";
+
+// Language-specific details of the edition (JAVASCRIPT* tags, "//" by default).
+const lang = getEdition().language;
 
 const snippetStore = {};
 
@@ -12,9 +16,9 @@ export const setupSnippetsJs = node => {
   const snippets = node.getElementsByTagName("SNIPPET");
   for (let i = 0; snippets[i]; i++) {
     const snippet = snippets[i];
-    const jsSnippet = snippet.getElementsByTagName("JAVASCRIPT")[0];
-    let jsRunSnippet = snippet.getElementsByTagName("JAVASCRIPT_RUN")[0];
-    let jsTestSnippet = snippet.getElementsByTagName("JAVASCRIPT_TEST")[0];
+    const jsSnippet = snippet.getElementsByTagName(lang.blockTag)[0];
+    let jsRunSnippet = snippet.getElementsByTagName(lang.runTag)[0];
+    let jsTestSnippet = snippet.getElementsByTagName(lang.testTag)[0];
     if (jsTestSnippet) {
       jsRunSnippet = jsTestSnippet;
     } else {
@@ -60,10 +64,10 @@ const recursiveGetRequires = (name, seen) => {
 };
 
 export const processSnippetJs = (node, writeTo, fileFormat) => {
-  const jsSnippet = node.getElementsByTagName("JAVASCRIPT")[0];
+  const jsSnippet = node.getElementsByTagName(lang.blockTag)[0];
   if (jsSnippet) {
     if (node.getAttribute("CHAP") || node.getAttribute("VARIANT")) {
-      writeTo.push("// ");
+      writeTo.push(lang.commentPrefix + " ");
       if (node.getAttribute("CHAP")) {
         writeTo.push("chapter=" + node.getAttribute("CHAP") + " ");
       }
@@ -74,8 +78,8 @@ export const processSnippetJs = (node, writeTo, fileFormat) => {
     }
 
     // JavaScript source for running. Overrides JAVASCRIPT if present.
-    let jsRunSnippet = node.getElementsByTagName("JAVASCRIPT_RUN")[0];
-    let jsTestSnippet = node.getElementsByTagName("JAVASCRIPT_TEST")[0];
+    let jsRunSnippet = node.getElementsByTagName(lang.runTag)[0];
+    let jsTestSnippet = node.getElementsByTagName(lang.testTag)[0];
     if (jsTestSnippet) {
       jsRunSnippet = jsTestSnippet;
     } else {
@@ -144,7 +148,9 @@ export const processSnippetJs = (node, writeTo, fileFormat) => {
       writeTo.push(exampleStr);
       if (node.getElementsByTagName("EXPECTED")[0]) {
         writeTo.push(
-          "\n// expected: " +
+          "\n" +
+            lang.commentPrefix +
+            " expected: " +
             node.getElementsByTagName("EXPECTED")[0].firstChild.nodeValue +
             "\n"
         );


### PR DESCRIPTION
Stage of the language-axis refactor (follows #1214, #1216, #1217, #1218), completing the **js** (extracted programs) pipeline.

`processSnippetJs.js`:
- tag lookups → `lang.blockTag` / `lang.runTag` / `lang.testTag`
- the `// ` chapter/variant annotation and the `// expected:` line → `lang.commentPrefix` (so they become `# ` / `# expected:` for the Python edition)

## No-op
With the default JavaScript edition every descriptor field equals the literal it replaced.

Verified: after saturating the (racy, unawaited) `yarn js` build, `js_programs` has **no content differences** vs master (`diff -rq` → 0). Prettier clean; no new `tsc` errors.

Remaining stages: `parseXmlHtml` (+ html `processingFunctions`, plus the `version` split/scheme/js machinery) and `parseXmlLatex` (+ pdf).