### PR TITLE
Refactor (no-op): thread language descriptor through parseXmlHtml tag references

### DIFF
--- a/javascript/parseXmlHtml.tsx
+++ b/javascript/parseXmlHtml.tsx
@@ -21,6 +21,10 @@ import {
 import LinksHead from "./html/LinksHead.js";
 import type { WriteBuffer } from "./types.js";
 import { raw } from "hono/html";
+import { getEdition } from "./editions.js";
+
+// Tag names of the edition's non-Scheme language (JAVASCRIPT* by default).
+const lang = getEdition().language;
 
 let paragraph_count = 0;
 let heading_count = 0;
@@ -77,7 +81,7 @@ const ignoreTags = new Set([
   "CHAPTERCONTENT",
   "SPLIT",
   "SPLITINLINE",
-  "JAVASCRIPT",
+  lang.blockTag,
   "WEB_ONLY"
 ]);
 
@@ -370,9 +374,9 @@ let processTextFunctionsHtml = {
   },
 
   SCHEMEINLINE: (node, writeTo) =>
-    processTextFunctionsHtml["JAVASCRIPTINLINE"](node, writeTo),
+    processTextFunctionsHtml[lang.inlineTag](node, writeTo),
 
-  JAVASCRIPTINLINE: (node, writeTo) => {
+  [lang.inlineTag]: (node, writeTo) => {
     if (
       node.firstChild &&
       node.firstChild.data &&
@@ -400,7 +404,7 @@ let processTextFunctionsHtml = {
     if (node.getAttribute("HIDE") == "yes") {
       return;
     } else if (node.getAttribute("LATEX") == "yes") {
-      const textprompt = getChildrenByTagName(node, "JAVASCRIPT_PROMPT")[0];
+      const textprompt = getChildrenByTagName(node, lang.promptTag)[0];
       if (textprompt) {
         writeTo.push("<kbd class='snippet-prompt'>");
         recursiveProcessTextHtml(textprompt.firstChild, writeTo, {
@@ -410,7 +414,7 @@ let processTextFunctionsHtml = {
       }
 
       writeTo.push("<kbd class='snippet'>");
-      const textit = getChildrenByTagName(node, "JAVASCRIPT")[0];
+      const textit = getChildrenByTagName(node, lang.blockTag)[0];
       if (textit) {
         recursiveProcessTextHtml(textit.firstChild, writeTo, {
           removeNewline: "beginning&end"
@@ -420,7 +424,7 @@ let processTextFunctionsHtml = {
       }
       writeTo.push("</kbd>");
 
-      const textoutput = getChildrenByTagName(node, "JAVASCRIPT_OUTPUT")[0];
+      const textoutput = getChildrenByTagName(node, lang.outputTag)[0];
       if (textoutput) {
         writeTo.push("<kbd class='snippet-output'>");
         recursiveProcessTextHtml(textoutput.firstChild, writeTo, {
@@ -559,7 +563,7 @@ const processTextFunctionsSplit = {
     writeTo.push(`</span>`);
   },
 
-  JAVASCRIPT: (node, writeTo) => {
+  [lang.blockTag]: (node, writeTo) => {
     writeTo.push(`<span style="color:blue">`);
     recursiveProcessTextHtml(node.firstChild, writeTo);
     writeTo.push(`</span>`);
@@ -567,7 +571,7 @@ const processTextFunctionsSplit = {
 
   SPLIT: (node, writeTo) => {
     const scheme = getChildrenByTagName(node, "SCHEME")[0];
-    const js = getChildrenByTagName(node, "JAVASCRIPT")[0];
+    const js = getChildrenByTagName(node, lang.blockTag)[0];
     writeTo.push(`<table width="100%">
         <colgroup><col width="48%"><col width="1%"><col width="51%"></colgroup>
         <tr>
@@ -602,7 +606,7 @@ const processTextFunctionsSplit = {
 
     if (ancestorHasTag(node, "SCHEME")) {
       writeTo.push(`style="color:green"`);
-    } else if (ancestorHasTag(node, "JAVASCRIPT")) {
+    } else if (ancestorHasTag(node, lang.blockTag)) {
       writeTo.push(`style="color:blue"`);
     }
 
@@ -613,7 +617,7 @@ const processTextFunctionsSplit = {
 
     if (ancestorHasTag(node, "SCHEME")) {
       cloneNode.setAttribute("version", "scheme");
-    } else if (ancestorHasTag(node, "JAVASCRIPT")) {
+    } else if (ancestorHasTag(node, lang.blockTag)) {
       cloneNode.setAttribute("version", "js");
     }
 
@@ -669,9 +673,9 @@ const processTextFunctionsSplit = {
     const scheme = getChildrenByTagName(node, "SCHEME")[0];
     const scheme_prompt = getChildrenByTagName(node, "SCHEMEPROMPT")[0];
     const scheme_output = getChildrenByTagName(node, "SCHEMEOUTPUT")[0];
-    const js = getChildrenByTagName(node, "JAVASCRIPT")[0];
-    const js_prompt = getChildrenByTagName(node, "JAVASCRIPT_PROMPT")[0];
-    const js_output = getChildrenByTagName(node, "JAVASCRIPT_OUTPUT")[0];
+    const js = getChildrenByTagName(node, lang.blockTag)[0];
+    const js_prompt = getChildrenByTagName(node, lang.promptTag)[0];
+    const js_output = getChildrenByTagName(node, lang.outputTag)[0];
     if (
       (scheme || scheme_output || scheme_prompt) &&
       (js || js_output || js_prompt)


### PR DESCRIPTION
Stage of the language-axis refactor — the HTML/comparison parser. Scoped to the **tag references** in `parseXmlHtml.tsx` (13 sites) to keep it reviewable.

Replaces hardcoded `JAVASCRIPT*` with the edition descriptor:
- `ignoreTags` entry → `lang.blockTag`
- inline handler key `[lang.inlineTag]` + `SCHEMEINLINE` delegation
- snippet / `SPLIT` / footnote tag lookups → `lang.blockTag` / `lang.promptTag` / `lang.outputTag`
- the `JAVASCRIPT` colored-span handler key in the comparison map (`processTextFunctionsSplit`)

## No-op — two oracles
`parseXmlHtml` is exercised by both the web build and the json build (TOC titles go through `recursiveProcessTextHtml`).
- `yarn json`: **byte-for-byte identical** to master.
- `yarn split` (`html_split`, saturated for the racy unawaited build): **no content differences**.

Prettier clean; no new `tsc` errors.

## Deliberately deferred (follow-up)
Not in this PR, because they span multiple files and/or need a new descriptor field:
- the `version == "js"` / `setAttribute("version", "js")` machinery → `lang.key` (also touches `index.ts`, `generateTocHtml`, `htmlContent`, `LinksHead`)
- the `"JavaScript"` comparison-column header → a new `languageName` field (`"JavaScript"`/`"Python"`)

Also still to do: the html `processingFunctions` (`processSnippetHtml`, `processReferenceHtml`, `processExerciseHtml`, `processFigureHtml`) and the pdf side (`parseXmlLatex`).