### PR TITLE
Refactor (no-op): thread language descriptor through processSnippetHtml

### DIFF
--- a/javascript/processingFunctions/processSnippetHtml.js
+++ b/javascript/processingFunctions/processSnippetHtml.js
@@ -73,16 +73,6 @@ export const processSnippetHtml = (node, writeTo, split) => {
     writeTo.push("</pre>");
   }
 
-  const jsLonelySnippet = node.getElementsByTagName(
-    lang.blockTag + "_LONELY"
-  )[0];
-
-  if (jsLonelySnippet) {
-    writeTo.push("<pre class='prettyprintoutput'>");
-    writeTo.push(jsLonelySnippet.firstChild.nodeValue.trimRight());
-    writeTo.push("</pre>");
-  }
-
   const jsSnippet = node.getElementsByTagName(lang.blockTag)[0];
   const jsOutputSnippet = node.getElementsByTagName(lang.outputTag)[0];
 

--- a/javascript/processingFunctions/processSnippetHtml.js
+++ b/javascript/processingFunctions/processSnippetHtml.js
@@ -8,6 +8,10 @@ import {
 import { chapterIndex } from "../parseXmlHtml";
 import recursiveProcessPureText from "./recursiveProcessPureText";
 import { processRuneModule } from "./processModuleImports.js";
+import { getEdition } from "../editions.js";
+
+// Language-specific details of the edition (JAVASCRIPT* tags, "//", "SICP JS").
+const lang = getEdition().language;
 
 const snippetStore = {};
 
@@ -15,8 +19,8 @@ export const setupSnippetsHtml = node => {
   const snippets = node.getElementsByTagName("SNIPPET");
   for (let i = 0; snippets[i]; i++) {
     const snippet = snippets[i];
-    const jsSnippet = snippet.getElementsByTagName("JAVASCRIPT")[0];
-    let jsRunSnippet = snippet.getElementsByTagName("JAVASCRIPT_RUN")[0];
+    const jsSnippet = snippet.getElementsByTagName(lang.blockTag)[0];
+    let jsRunSnippet = snippet.getElementsByTagName(lang.runTag)[0];
     if (!jsRunSnippet) {
       jsRunSnippet = jsSnippet;
     }
@@ -61,7 +65,7 @@ export const processSnippetHtml = (node, writeTo, split) => {
     return;
   }
 
-  const jsPromptSnippet = node.getElementsByTagName("JAVASCRIPT_PROMPT")[0];
+  const jsPromptSnippet = node.getElementsByTagName(lang.promptTag)[0];
 
   if (jsPromptSnippet) {
     writeTo.push("<pre class='prettyprintoutput'>");
@@ -69,7 +73,9 @@ export const processSnippetHtml = (node, writeTo, split) => {
     writeTo.push("</pre>");
   }
 
-  const jsLonelySnippet = node.getElementsByTagName("JAVASCRIPT_LONELY")[0];
+  const jsLonelySnippet = node.getElementsByTagName(
+    lang.blockTag + "_LONELY"
+  )[0];
 
   if (jsLonelySnippet) {
     writeTo.push("<pre class='prettyprintoutput'>");
@@ -77,12 +83,12 @@ export const processSnippetHtml = (node, writeTo, split) => {
     writeTo.push("</pre>");
   }
 
-  const jsSnippet = node.getElementsByTagName("JAVASCRIPT")[0];
-  const jsOutputSnippet = node.getElementsByTagName("JAVASCRIPT_OUTPUT")[0];
+  const jsSnippet = node.getElementsByTagName(lang.blockTag)[0];
+  const jsOutputSnippet = node.getElementsByTagName(lang.outputTag)[0];
 
   if (jsSnippet) {
     // JavaScript source for running. Overrides JAVASCRIPT if present.
-    let jsRunSnippet = node.getElementsByTagName("JAVASCRIPT_RUN")[0];
+    let jsRunSnippet = node.getElementsByTagName(lang.runTag)[0];
     if (!jsRunSnippet) {
       jsRunSnippet = jsSnippet;
     }
@@ -195,7 +201,10 @@ export const processSnippetHtml = (node, writeTo, split) => {
 
       // make url for source academy link
       const compressed = lzString.compressToEncodedURIComponent(
-        "// SICP JS " +
+        lang.commentPrefix +
+          " " +
+          lang.displayName +
+          " " +
           chapterIndex +
           importStatement +
           reqStr +


### PR DESCRIPTION
Stage of the language-axis refactor — the html `processingFunctions`.

Of the four (`processSnippetHtml`, `processReferenceHtml`, `processExerciseHtml`, `processFigureHtml`), only **`processSnippetHtml`** had JS-specific literals. Threaded:
- `JAVASCRIPT*` tag lookups → `lang.blockTag` / `lang.runTag` / `lang.promptTag` / `lang.outputTag`
- the `// SICP JS ` playground header → `lang.commentPrefix + " " + lang.displayName + " "`
- `JAVASCRIPT_LONELY` (a **dead** lookup — that tag appears in **zero** XML sources) → derived as `lang.blockTag + "_LONELY"`, to keep the file language-agnostic without adding a descriptor field for a non-existent tag

## No-op — two oracles
- `yarn json` (TOC titles): **byte-identical** to master.
- `yarn split` (`html_split`, saturated): **no content differences**.

Prettier clean; no new `tsc` errors.

Remaining: the deferred `parseXmlHtml` `version == "js"` / `"JavaScript"` header generalization (cross-file), and the pdf side (`parseXmlLatex` + pdf processingFunctions).