### PR TITLE
Simplify redundant condition in processSnippetPdf

### DIFF
--- a/javascript/processingFunctions/processSnippetPdf.js
+++ b/javascript/processingFunctions/processSnippetPdf.js
@@ -419,7 +419,7 @@ export const processSnippetPdf = (node, writeTo) => {
   if (jsOutputSnippet) {
     if (jsPromptSnippet) {
       writeTo.push("\\InputOutputSpace");
-    } else if (jsPromptSnippet || jsSnippet) {
+    } else if (jsSnippet) {
       writeTo.push("\\InputOutputNoSpace");
     }
 


### PR DESCRIPTION
Small follow-up to #1223 (the Gemini nit landed after that PR was merged).

In the `if (jsOutputSnippet)` branch, the `else if` is the `else` of `if (jsPromptSnippet)`, so `jsPromptSnippet` is guaranteed falsy there. Thus `jsPromptSnippet || jsSnippet` reduces to `jsSnippet`. Behavior-identical; prettier + types clean.