### PR TITLE
Thread comparison-edition header and footnote marker through descriptor

### DIFF
--- a/javascript/editions.ts
+++ b/javascript/editions.ts
@@ -12,7 +12,7 @@
 
 // Language-specific details of the edition's non-Scheme language.
 export type LanguageDescriptor = {
-  readonly key: string; // short identifier, also used in output naming, e.g. "js"
+  readonly key: string; // short identifier, also used in output naming and as the footnote "version" marker, e.g. "js"
   // XML tag names that carry the language's code.
   readonly blockTag: string; // code block, e.g. "JAVASCRIPT"
   readonly inlineTag: string; // inline code, e.g. "JAVASCRIPTINLINE"
@@ -23,6 +23,7 @@ export type LanguageDescriptor = {
   // Surface strings emitted into generated output.
   readonly commentPrefix: string; // line-comment marker, e.g. "//" (Python: "#")
   readonly displayName: string; // edition name in headers, e.g. "SICP JS" (Python: "SICPy")
+  readonly languageName: string; // language name in the comparison-edition column header, e.g. "JavaScript" (Python: "Python")
   readonly fileExtension: string; // extracted-program extension, e.g. ".js" (Python: ".py")
 };
 
@@ -36,12 +37,14 @@ export const javascriptLanguage: LanguageDescriptor = {
   promptTag: "JAVASCRIPT_PROMPT",
   commentPrefix: "//",
   displayName: "SICP JS",
+  languageName: "JavaScript",
   fileExtension: ".js"
 };
 
 // The Python edition will add (in a later step):
 //   key: "py", blockTag: "PYTHON", inlineTag: "PYTHONINLINE", ...,
-//   commentPrefix: "#", displayName: "SICPy", fileExtension: ".py"
+//   commentPrefix: "#", displayName: "SICPy", languageName: "Python",
+//   fileExtension: ".py"
 
 // An edition ties a language to its source tree and output naming.
 export type Edition = {

--- a/javascript/parseXmlHtml.tsx
+++ b/javascript/parseXmlHtml.tsx
@@ -577,7 +577,7 @@ const processTextFunctionsSplit = {
         <tr>
           <td class="meta" style = "color:grey; text-align: center">Original</td>
           <td></td>
-          <td class="meta" style = "color:grey; text-align: center">JavaScript</td>
+          <td class="meta" style = "color:grey; text-align: center">${lang.languageName}</td>
         </tr>`);
     writeTo.push(`
         <tr><td>`);
@@ -618,7 +618,7 @@ const processTextFunctionsSplit = {
     if (ancestorHasTag(node, "SCHEME")) {
       cloneNode.setAttribute("version", "scheme");
     } else if (ancestorHasTag(node, lang.blockTag)) {
-      cloneNode.setAttribute("version", "js");
+      cloneNode.setAttribute("version", lang.key);
     }
 
     let parent = node.parentNode;
@@ -639,14 +639,14 @@ const processTextFunctionsSplit = {
     <div class='footnote'>`);
     if (node.getAttribute("version") == "scheme") {
       writeTo.push(`<span style="color:green">`);
-    } else if (node.getAttribute("version") == "js") {
+    } else if (node.getAttribute("version") == lang.key) {
       writeTo.push(`<span style="color:blue">`);
     }
     writeTo.push(`
       <a class='footnote-number' id='footnote-${display_footnote_count}' href='#footnote-link-${display_footnote_count}' `);
     if (node.getAttribute("version") == "scheme") {
       writeTo.push(`style="color:green"`);
-    } else if (node.getAttribute("version") == "js") {
+    } else if (node.getAttribute("version") == lang.key) {
       writeTo.push(`style="color:blue"`);
     }
     writeTo.push(`>[${display_footnote_count}] </a>
@@ -686,7 +686,7 @@ const processTextFunctionsSplit = {
       writeTo.push(`
           <tr>
             <td class="meta" style = "color:grey; text-align: center">Original</td>
-            <td class="meta" style = "color:grey; text-align: center">JavaScript</td>
+            <td class="meta" style = "color:grey; text-align: center">${lang.languageName}</td>
           </tr>
           <tr>
             <td>`);


### PR DESCRIPTION
Picks up the two language-specific literals in the comparison (split) HTML edition that were deferred when `parseXmlHtml.tsx` was first threaded.

## What changed
- **Comparison-edition column header**: the `"JavaScript"` header shown beside the Scheme `"Original"` column (two sites) now uses a new `languageName` descriptor field (`"JavaScript"` for SICP JS, `"Python"` for SICPy).
- **Footnote `version` marker**: footnotes are tagged `version="scheme"` (green) or `version="js"` (blue) depending on whether they descend from `<SCHEME>` or the non-Scheme language block. The non-Scheme value and its two readers now use `lang.key` instead of the literal `"js"`. The `<SCHEME>` anchor stays fixed.

## Out of scope (intentionally)
The edition-mode selector `"js"` (`switchTitle` / `switchParseFunctionsHtml` / the `web` dispatch in `index.ts`) is a **different axis** — standalone vs `"split"` vs `"scheme"` web edition — not the language tag, so it is left alone. (The standalone `web js` target isn't even wired to an output dir.)

## Verification
No-op for SICP JS. Both changes appear only in the comparison edition, exercised by `yarn split`. After saturating the build's raciness, `diff -rq` against the golden `html_split` tree shows **no content differences**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)