### PR TITLE
Thread language descriptor through findBadTags

### DIFF
--- a/javascript/findBadTags.ts
+++ b/javascript/findBadTags.ts
@@ -3,13 +3,18 @@ import util from "node:util";
 import path from "node:path";
 
 import { DOMParser as dom } from "xmldom";
+import { getEdition } from "./editions.js";
 
 const readdir = util.promisify(fs.readdir);
 const open = util.promisify(fs.open);
 const readFile = util.promisify(fs.readFile);
 
+// Source tree and tag names of the edition being checked (JS / "xml" by default).
+const edition = getEdition();
+const lang = edition.language;
+
 const __dirname = path.resolve(import.meta.dirname);
-const inputDir = path.join(__dirname, "../xml");
+const inputDir = path.join(__dirname, "..", edition.inputDirName);
 
 const validTags = new Set([
   // symbols
@@ -51,16 +56,16 @@ const validTags = new Set([
   "HISTORY",
   "NAME",
   "EXPECTED",
-  "JAVASCRIPT_RUN",
-  "JAVASCRIPT_TEST",
-  "JAVASCRIPT_OUTPUT",
+  lang.runTag,
+  lang.testTag,
+  lang.outputTag,
   "ORDER",
   "SCHEME",
   "SOLUTION",
 
   // ignoreTags (treat tag as meaningless wrapper)
   "CHAPTERCONTENT",
-  "JAVASCRIPT",
+  lang.blockTag,
   "SECTIONCONTENT",
   "span",
   "SPLIT",
@@ -102,7 +107,7 @@ const validTags = new Set([
   "SECTION",
   "SUBSUBSECTION",
   "SCHEMEINLINE",
-  "JAVASCRIPTINLINE",
+  lang.inlineTag,
   "SNIPPET",
   "SUBHEADING",
   "SUBINDEX",

--- a/javascript/findBadTags.ts
+++ b/javascript/findBadTags.ts
@@ -59,6 +59,7 @@ const validTags = new Set([
   lang.runTag,
   lang.testTag,
   lang.outputTag,
+  lang.promptTag,
   "ORDER",
   "SCHEME",
   "SOLUTION",


### PR DESCRIPTION
Threads the standalone `findBadTags` diagnostic through `getEdition()`, continuing the language-axis refactor.

## What changed
- The `JAVASCRIPT` / `JAVASCRIPTINLINE` / `JAVASCRIPT_RUN` / `JAVASCRIPT_TEST` / `JAVASCRIPT_OUTPUT` entries in the `validTags` allow-list now use `lang.blockTag` / `lang.inlineTag` / `lang.runTag` / `lang.testTag` / `lang.outputTag`.
- The hardcoded `"xml"` source directory now uses `edition.inputDirName`, so the tool can check `xml_py/` for the Python edition (the same threading `index.ts` already uses).
- **One behavioral fix** (per Gemini review): added `lang.promptTag` (`JAVASCRIPT_PROMPT`) to the allow-list. It was a pre-existing omission — the tag appears in 10 source files and was being false-flagged as invalid.

## Verification
`findBadTags` isn't part of any `yarn` build, so it's verified by its own output across a default run (all invalid tags), a tag-specific run, and a no-match run:
- The threading is a **pure no-op**.
- The `promptTag` addition's **only** effect is removing the 34 pre-existing `JAVASCRIPT_PROMPT found.` false positives — nothing else added or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)