### PR TITLE
Thread language descriptor through the PDF/LaTeX pipeline

### DIFF
--- a/javascript/parseXmlLatex.js
+++ b/javascript/parseXmlLatex.js
@@ -1,6 +1,7 @@
 import { getChildrenByTagName, ancestorHasTag } from "./utilityFunctions";
 
 import { parseType } from "./index";
+import { getEdition } from "./editions.js";
 
 import {
   replaceTagWithSymbol,
@@ -20,6 +21,9 @@ import {
 // set true to generate index annotations
 // in the margins of the text
 const indexAnnotations = false;
+
+// Tag names of the edition's non-Scheme language (JAVASCRIPT* by default).
+const lang = getEdition().language;
 
 const tagsToRemove = new Set([
   "#comment",
@@ -48,7 +52,7 @@ const tagsToRemove = new Set([
 
 const ignoreTags = new Set([
   "CHAPTERCONTENT",
-  "JAVASCRIPT",
+  lang.blockTag,
   "SECTIONCONTENT",
   "span",
   "SPLIT",
@@ -63,12 +67,12 @@ const processTextFunctionsDefaultLatex = {
     } else {
       trimedValue = node.nodeValue;
       if (
-        node.parentNode.nodeName === "JAVASCRIPTINLINE" &&
+        node.parentNode.nodeName === lang.inlineTag &&
         node.parentNode.parentNode.nodeName === "CAPTION"
       ) {
         trimedValue = trimedValue.replace(/\{/g, "\\{").replace(/\}/g, "\\}");
       } else {
-        if (node.parentNode.nodeName !== "JAVASCRIPTINLINE") {
+        if (node.parentNode.nodeName !== lang.inlineTag) {
           trimedValue = trimedValue.replace(/%/g, "\\%");
         }
       }
@@ -87,8 +91,8 @@ const processTextFunctionsDefaultLatex = {
   },
 
   SPLITINLINE: (node, writeTo) => {
-    if (getChildrenByTagName(node, "JAVASCRIPTINLINE")[0]) {
-      console.error("remove 'INLINE' from tag JAVASCRIPTINLINE");
+    if (getChildrenByTagName(node, lang.inlineTag)[0]) {
+      console.error("remove 'INLINE' from tag " + lang.inlineTag);
     }
     if (getChildrenByTagName(node, "SCHEMEINLINE")[0]) {
       console.error("remove 'INLINE' from tag SCHEMEINLINE");
@@ -252,7 +256,7 @@ const processTextFunctionsDefaultLatex = {
   },
 
   META: (node, writeTo) => {
-    if (ancestorHasTag(node, "JAVASCRIPT_OUTPUT")) {
+    if (ancestorHasTag(node, lang.outputTag)) {
       writeTo.push("^");
     }
     writeTo.push("$\\mathit{");
@@ -260,7 +264,7 @@ const processTextFunctionsDefaultLatex = {
     s = s.replace(/-/g, "\\mhyphen{}").replace(/ /g, "\\ ");
     writeTo.push(s);
     writeTo.push("}$");
-    if (ancestorHasTag(node, "JAVASCRIPT_OUTPUT")) {
+    if (ancestorHasTag(node, lang.outputTag)) {
       writeTo.push("^");
     }
   },
@@ -649,13 +653,13 @@ const processTextFunctionsDefaultLatex = {
   },
 
   SCHEMEINLINE: (node, writeTo) =>
-    processTextFunctionsLatex["JAVASCRIPTINLINE"](node, writeTo),
+    processTextFunctionsLatex[lang.inlineTag](node, writeTo),
   DECLARATION: (node, writeTo) =>
-    processTextFunctionsLatex["JAVASCRIPTINLINE"](node, writeTo),
+    processTextFunctionsLatex[lang.inlineTag](node, writeTo),
   USE: (node, writeTo) =>
-    processTextFunctionsLatex["JAVASCRIPTINLINE"](node, writeTo),
+    processTextFunctionsLatex[lang.inlineTag](node, writeTo),
   ECMA: (node, writeTo) => {},
-  JAVASCRIPTINLINE: (node, writeTo) => {
+  [lang.inlineTag]: (node, writeTo) => {
     if (ancestorHasTag(node, "METAPHRASE")) {
       writeTo.push("}$");
       recursiveProcessPureText(node.firstChild, writeTo, { type: parseType });

--- a/javascript/processingFunctions/processSnippetPdf.js
+++ b/javascript/processingFunctions/processSnippetPdf.js
@@ -9,6 +9,10 @@ import {
 } from "./warnings.js";
 import { recursiveProcessTextLatex, processTextLatex } from "../parseXmlLatex";
 import recursiveProcessPureText from "./recursiveProcessPureText";
+import { getEdition } from "../editions.js";
+
+// Tag names of the edition's non-Scheme language (JAVASCRIPT* by default).
+const lang = getEdition().language;
 
 const snippetStore = {};
 
@@ -16,8 +20,8 @@ export const setupSnippetsPdf = node => {
   const snippets = node.getElementsByTagName("SNIPPET");
   for (let i = 0; snippets[i]; i++) {
     const snippet = snippets[i];
-    const jsSnippet = snippet.getElementsByTagName("JAVASCRIPT")[0];
-    let jsRunSnippet = snippet.getElementsByTagName("JAVASCRIPT_RUN")[0];
+    const jsSnippet = snippet.getElementsByTagName(lang.blockTag)[0];
+    let jsRunSnippet = snippet.getElementsByTagName(lang.runTag)[0];
     if (!jsRunSnippet) {
       jsRunSnippet = jsSnippet;
     }
@@ -121,9 +125,9 @@ export const processSnippetPdf = (node, writeTo) => {
       : "\\PostBoxCmd%\n";
   const midSpace = inFigure ? "\\smallskip" : "";
 
-  const jsPromptSnippet = node.getElementsByTagName("JAVASCRIPT_PROMPT")[0];
-  const jsSnippet = node.getElementsByTagName("JAVASCRIPT")[0];
-  const jsOutputSnippet = node.getElementsByTagName("JAVASCRIPT_OUTPUT")[0];
+  const jsPromptSnippet = node.getElementsByTagName(lang.promptTag)[0];
+  const jsSnippet = node.getElementsByTagName(lang.blockTag)[0];
+  const jsOutputSnippet = node.getElementsByTagName(lang.outputTag)[0];
   const allowBreakAfter =
     jsSnippet && jsSnippet.getAttribute("BREAK_AFTER") === "yes"
       ? "\\pagebreak"
@@ -174,7 +178,7 @@ export const processSnippetPdf = (node, writeTo) => {
 
   if (jsSnippet) {
     // JavaScript source for running. Overrides JAVASCRIPT if present.
-    let jsRunSnippet = node.getElementsByTagName("JAVASCRIPT_RUN")[0];
+    let jsRunSnippet = node.getElementsByTagName(lang.runTag)[0];
     if (!jsRunSnippet) {
       jsRunSnippet = jsSnippet;
     }


### PR DESCRIPTION
Final tag-threading stage of the language-axis refactor: routes the hardcoded `JAVASCRIPT*` XML tag names in `parseXmlLatex.js` and `processSnippetPdf.js` through `getEdition().language`.

## What changed
- `parseXmlLatex.js`: the `ignoreTags` block-tag entry, the `JAVASCRIPTINLINE` handler key and its `SCHEMEINLINE`/`DECLARATION`/`USE` delegations, the `parentNode.nodeName` inline checks, the `getChildrenByTagName` inline lookup, the `JAVASCRIPT_OUTPUT` ancestor checks, and the `remove 'INLINE'` diagnostic now use `lang.blockTag` / `lang.inlineTag` / `lang.outputTag`.
- `processSnippetPdf.js`: the block / run / prompt / output `getElementsByTagName` lookups now use `lang.blockTag` / `lang.runTag` / `lang.promptTag` / `lang.outputTag`.

## Out of scope (intentionally)
The LaTeX environment/macro names (`JavaScriptPrompt`, `JavaScriptOutput`, `JavaScript`+`LatexString`, `JavaScriptClickable`, …) are the **rendering layer**, defined in `latexContent.js`, and belong to a separate axis (along with the `"JavaScript Edition"` title strings). They are left unchanged.

## Verification
No-op for SICP JS, proven at the `.tex` layer (the deterministic output my code produces): `yarn process pdf` yields **byte-identical** output for every deterministic `.tex` file. `answers.tex` is identical as a *set* — it differs only by an async-completion ordering that is already non-deterministic on master (two unmodified builds reorder it too). Since the `.tex` LaTeX consumes is unchanged, the compiled PDF is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)