### PR TITLE
Thread language name through mechanical PDF/search surface strings

### DIFF
--- a/javascript/latexContent.js
+++ b/javascript/latexContent.js
@@ -744,7 +744,7 @@ export const frontmatter = `
 \\HalfTitle{\\fontsize{16}{20}\\selectfont Structure and Interpretation of Computer Programs
 \\begin{minipage}{12cm}
 \\vspace{3.5mm}
-\\normalsize {\\fontsize{13}{18}\\selectfont JavaScript Edition}
+\\normalsize {\\fontsize{13}{18}\\selectfont ${languageName} Edition}
 \\end{minipage}
 }
 
@@ -754,7 +754,7 @@ export const frontmatter = `
 
 \\Title{\\fontsize{16}{20}\\selectfont Structure and Interpretation of Computer Programs}
 
-\\edition{\\fontsize{13}{18}\\selectfont JavaScript Edition}
+\\edition{\\fontsize{13}{18}\\selectfont ${languageName} Edition}
 
 \\BookAuthor{\\fontsize{13}{18}\\selectfont Harold Abelson and Gerald Jay Sussman
 \\begin{minipage}{12cm}
@@ -898,7 +898,7 @@ you were first led up to it, that you can make it more.''\\end{minipage}}{\\norm
 \\HalfTitle{\\fontsize{16}{20}\\selectfont Structure and Interpretation of Computer Programs
 \\begin{minipage}{12cm}
 \\vspace{3.5mm}
-\\normalsize {\\fontsize{13}{18}\\selectfont JavaScript Edition}
+\\normalsize {\\fontsize{13}{18}\\selectfont ${languageName} Edition}
 \\end{minipage}
 }
 \\halftitlepage

--- a/javascript/parseXmlLatex.js
+++ b/javascript/parseXmlLatex.js
@@ -310,12 +310,12 @@ const processTextFunctionsDefaultLatex = {
       marginStr += "operators (...)";
     }
     if (functioN) {
-      indexStr += "function (JavaScript)";
-      marginStr += "function (JavaScript)";
+      indexStr += "function (" + lang.languageName + ")";
+      marginStr += "function (" + lang.languageName + ")";
     }
     if (parsing) {
-      indexStr += "parsing JavaScript";
-      marginStr += "parsing JavaScript";
+      indexStr += "parsing " + lang.languageName;
+      marginStr += "parsing " + lang.languageName;
     }
 
     // handle explicit order commands ORDER, DECLARATION, USE

--- a/javascript/searchRewrite.ts
+++ b/javascript/searchRewrite.ts
@@ -33,10 +33,10 @@ const indexParsers = {
     json["text"] += "operators";
   },
   PARSING: (node, json) => {
-    json["text"] += "parsing JavaScript";
+    json["text"] += "parsing " + lang.languageName;
   },
   FUNCTION: (node, json) => {
-    json["text"] += "function (JavaScript)";
+    json["text"] += "function (" + lang.languageName + ")";
   },
   PRIMITIVE: (node, json) => {
     json["text"] +=


### PR DESCRIPTION
Makes the clearly language-named build-tooling strings edition-aware via `lang.languageName` (`JavaScript` / `Python`), so they aren't hardcoded to JavaScript in the Python build.

## What changed
- **`latexContent.js`**: the `"<lang> Edition"` title (half-title, title page, series page) → `${languageName} Edition`.
- **`parseXmlLatex.js`**: the `"function (<lang>)"` and `"parsing <lang>"` index/margin entries generated from `<FUNCTION/>` / `<PARSING/>` tags.
- **`searchRewrite.ts`**: the same `"function (<lang>)"` / `"parsing <lang>"` entries in the JSON search index.

## Verification
- **No-op for SICP JS** (`languageName` = `"JavaScript"`): `yarn json` and `yarn process pdf` are **byte-identical** to master (tex diff excl. the racy `answers.tex`, which is identical as a set).
- **Python**: `SICP_EDITION=py` now renders **"Python Edition"** on the title pages and **"function (Python)"** / **"parsing Python"** in the chapter `.tex` index entries (confirmed in `latex_pdf_py/`).

## Deliberately NOT changed — editorial / edition-specific
Left for your editorial pass, since these aren't a mechanical language-name swap:
- The front-matter **copyright + Library of Congress CIP block** — LCCN 2021047249, ISBN, `[2022]`, adapter names, `JavaScript (Computer program language)` (LCSH), `Javascript edition`. All specific to the published JS book; a Python edition gets its own CIP data.
- The **`adapted to JavaScript by Martin Henz and Tobias Wrigstad`** attribution (Python adapters are an editorial decision) and the GPL derivation note.
- The index header **"Page numbers for JavaScript declarations"** — *declarations* vs *definitions* is a Python terminology call.
- `html/Attribution.tsx` and `html/Licences.tsx` (authorship / licensing).

These overlap with the larger `xml_py/` content/editorial pass (the ~945 prose occurrences), which is separate from the build tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)