### PR TITLE
Deploy the Python edition additively (split_py/, json_py/, sicpy.pdf)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -30,17 +30,35 @@ jobs:
           sudo apt-get install -y texlive texlive-fonts-extra latexmk
       - name: Fetch Yarn dependencies
         run: yarn install --frozen-lockfile
-      - name: Build
+      - name: Build (JavaScript edition)
         run: |
           set -euxo pipefail
           yarn run pdf || (cat latex_pdf_js/sicpjs.log && false)
           yarn run split
           yarn run programs
           yarn run json
-      - name: Package
+      - name: Package (JavaScript edition)
+        run: yarn run prepare
+      # The Python edition is published additively (split_py/, json_py/,
+      # sicpy.pdf, sicpy.zip). Best-effort: any failure here must never block
+      # the already-assembled JavaScript deploy.
+      - name: Build (Python edition)
+        continue-on-error: true
+        env:
+          SICP_EDITION: py
         run: |
-          yarn run prepare
-          find docs_out -name .gitignore -delete -print
+          set -euxo pipefail
+          yarn run split
+          yarn run json
+          yarn run programs
+          yarn run pdf || (cat latex_pdf_py/sicpy.log && false)
+      - name: Package (Python edition)
+        continue-on-error: true
+        env:
+          SICP_EDITION: py
+        run: yarn run prepare
+      - name: Strip build .gitignore files
+        run: find docs_out -name .gitignore -delete -print
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/scripts/do.sh
+++ b/scripts/do.sh
@@ -84,8 +84,9 @@ prepare() {
 	else
 		WEB_DEST="${DOCS}/split_${LANG_KEY}"
 		JSON_DEST="${DOCS}/json_${LANG_KEY}"
-		mkdir -p "${WEB_DEST}/assets"
 	fi
+	# ensure the stylesheet's destination exists for either edition
+	mkdir -p "${WEB_DEST}/assets"
  	[ ! -f ${FAVICON} ] || cp ${FAVICON} ${WEB_DEST}/favicon.ico
  	[ ! -f ${STYLESHEET} ] || cp ${STYLESHEET} ${WEB_DEST}/assets/stylesheet.css
  	[ ! -f ${LATEX_PDF}/${PDF_FILE} ] || cp ${LATEX_PDF}/${PDF_FILE} ${DOCS}

--- a/scripts/do.sh
+++ b/scripts/do.sh
@@ -74,16 +74,28 @@ clean() {
 }
 
 prepare() {
- 	[ ! -f ${FAVICON} ] || cp ${FAVICON} ${DOCS}/favicon.ico
- 	[ ! -f ${STYLESHEET} ] || cp ${STYLESHEET} ${DOCS}/assets/stylesheet.css
+	# The JavaScript edition publishes at the docs_out root. Other editions
+	# publish under their own subfolders (split_<lang>/, json_<lang>/) and
+	# under distinct artifact names (sicpy.pdf / sicpy.zip), so they are purely
+	# additive and never disturb the JS site.
+	if [ "${LANG_KEY}" = "js" ]; then
+		WEB_DEST="${DOCS}"
+		JSON_DEST="${DOCS}/json"
+	else
+		WEB_DEST="${DOCS}/split_${LANG_KEY}"
+		JSON_DEST="${DOCS}/json_${LANG_KEY}"
+		mkdir -p "${WEB_DEST}/assets"
+	fi
+ 	[ ! -f ${FAVICON} ] || cp ${FAVICON} ${WEB_DEST}/favicon.ico
+ 	[ ! -f ${STYLESHEET} ] || cp ${STYLESHEET} ${WEB_DEST}/assets/stylesheet.css
  	[ ! -f ${LATEX_PDF}/${PDF_FILE} ] || cp ${LATEX_PDF}/${PDF_FILE} ${DOCS}
 	PDF_BASENAME="$(basename "${PDF_FILE}" .pdf)"
 	cp "${LATEX_PDF}/${PDF_BASENAME}."{log,ilg,ind,idx} ${DOCS} || :
- 	[ ! -f ${GENERATED_HTML}/index.html ] || cp -rf ${GENERATED_HTML}/* ${DOCS}
+ 	[ ! -f ${GENERATED_HTML}/index.html ] || cp -rf ${GENERATED_HTML}/* ${WEB_DEST}
  	[ ! -d ${GENERATED_PROGRAMS} ] || ( zip -r ${ZIP_FILE} ${GENERATED_PROGRAMS}; \
  	                              cp ${ZIP_FILE} ${DOCS} )
-	[ ! -d ${GENERATED_JSON} ] || ( rm -rf ${DOCS}/json; \
-                                    cp -rf ${GENERATED_JSON} ${DOCS}/json )
+	[ ! -d ${GENERATED_JSON} ] || ( rm -rf ${JSON_DEST}; \
+                                    cp -rf ${GENERATED_JSON} ${JSON_DEST} )
 }
 
 main $1


### PR DESCRIPTION
Publishes the SICPy edition alongside SICP JS on the existing GitHub Pages deploy, **without touching the JS site**. Per your call: unlinked, so invisible to users until a link is added — zero risk, lets us review the live Python artifacts.

## Layout (`docs_out/` → gh-pages)
```
docs_out/
├── index.html, chapters/, json/, sicpjs.pdf, sicpjs.zip   ← JS (root, UNCHANGED)
├── sicpy.pdf, sicpy.zip                                   ← Python PDF + programs
├── split_py/   (self-contained Python comparison edition)
└── json_py/    (Python JSON for the frontend)
```

## Changes
- **`do.sh prepare()`** — JS still publishes at the `docs_out` root; non-JS editions publish under `split_<lang>/` + `json_<lang>/` and as `sicpy.pdf`/`sicpy.zip`. For `LANG_KEY=js` the destinations are exactly `docs_out` / `docs_out/json` as before (JS unchanged). `split_<lang>/` is **self-contained** — the web build copies `static/` in and the HTML uses relative links, so it needs nothing from the root.
- **`deploy-pages.yml`** — after the JS build+package, build+package the Python edition with `SICP_EDITION=py`. Those steps are **`continue-on-error`**, so a Python failure can never block the already-assembled JS deploy (the editions use entirely separate build dirs, `*_js` vs `*_py`). The `.gitignore` strip now runs once after both.

## Safety / verification
- **JS deploy is unaffected**: JS paths in `prepare()` are byte-identical, and the Python steps are isolated + best-effort. Verified locally that the `docs_out` JS layout (root HTML, `json/` with 136 files, `sicpjs.zip`) is unchanged after the Python `prepare` runs, and the Python artifacts land in `split_py/` (with its own `assets/`), `json_py/`, and `sicpy.*` at root.
- The Python PDF compiles locally (confirmed by Martin), so `sicpy.pdf` should publish; if it ever fails, `continue-on-error` keeps JS green and just omits it.
- The workflow itself only runs on push to master, so it's first exercised on merge — the isolation is precisely so that first run can't break the JS site.

## Follow-ups (not here)
- Linking to the Python edition from anywhere (intentionally omitted).
- Wiring the Source Academy frontend to read the Python book from `/json_py` (cross-repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)