### PR TITLE
Move @import to the top of stylesheet.css (and fix @charset)

### DIFF
--- a/static/assets/stylesheet.css
+++ b/static/assets/stylesheet.css
@@ -1,4 +1,5 @@
-@charset "UTF-8"
+@charset "UTF-8";
+@import url(fonts.css);
 blockquote {
   margin: 18pt auto;
   padding: 13px;
@@ -733,7 +734,6 @@ ol.linenums{margin-top:0;margin-bottom:0;color:#aeaeae}li.L0,li.L1,li.L2,li.L3,l
 
 
  */
-@import url(fonts.css);
 /*!
  * Bootstrap v4.4.1 (https://getbootstrap.com/)
  * Copyright 2011-2019 The Bootstrap Authors


### PR DESCRIPTION
The browser was dropping `@import url(fonts.css);` in the split (comparison) edition with:

> An @import rule was ignored because it wasn't defined at the top of the stylesheet… (`stylesheet.css:736`)

`@import` must appear before any style declaration (only `@charset`/`@layer` may precede it), but it sat at **line 736** after hundreds of rules.

## Fix (`static/assets/stylesheet.css`)
- Moved `@import url(fonts.css);` to the **top**, right after `@charset`, and removed the stray one at line 736.
- Also added the missing **semicolon** to `@charset "UTF-8"` → `@charset "UTF-8";` (it was malformed — same "top of stylesheet" correctness).

`fonts.css` sits next to `stylesheet.css` in `static/assets/`, so the relative import resolves. This stylesheet is copied into the web build, so it ships in the deployed split edition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)