### PR TITLE
SICPy: replace equal() with == everywhere except its defining exercise

### DIFF
--- a/xml_py/chapter2/section3/subsection3.xml
+++ b/xml_py/chapter2/section3/subsection3.xml
@@ -238,7 +238,7 @@ def is_element_of_set(x, set):
     return (False
             if is_none(set)
             else True
-            if equal(x, head(set))
+            if x == head(set)
             else is_element_of_set(x, tail(set)))
       </PYTHON>
     </SNIPPET>
@@ -1870,7 +1870,7 @@ def lookup(given_key, set_of_records):
     return (False
             if is_none(set_of_records)
             else head(set_of_records)
-            if equal(given_key, key(head(set_of_records)))
+            if given_key == key(head(set_of_records))
             else lookup(given_key, tail(set_of_records)))
       </PYTHON>
     </SNIPPET>

--- a/xml_py/chapter2/section3/subsection4.xml
+++ b/xml_py/chapter2/section3/subsection4.xml
@@ -1019,9 +1019,9 @@ def encode_symbol(symbol, tree):
 	<REQUIRES>encode</REQUIRES>
 	<REQUIRES>sample_tree</REQUIRES>
 	<PYTHON>
-print(equal(encode(decode(sample_message, sample_tree),
-             sample_tree),
-      sample_message))
+print(encode(decode(sample_message, sample_tree),
+             sample_tree)
+      == sample_message)
 	</PYTHON>
       </SNIPPET>
     </SOLUTION>
@@ -1137,8 +1137,8 @@ sample_frequencies = llist(llist("A", 4),
                            llist("C", 1),
                            llist("D", 1))
 
-print(equal(sample_tree,
-      generate_huffman_tree(sample_frequencies)))
+print(sample_tree
+      == generate_huffman_tree(sample_frequencies))
 	</PYTHON>
       </SNIPPET>
     </SOLUTION>

--- a/xml_py/chapter2/section4/subsection3.xml
+++ b/xml_py/chapter2/section4/subsection3.xml
@@ -1615,7 +1615,7 @@ def assoc(key, records):
     return (None
             if is_none(records)
             else head(records)
-            if equal(key, head(head(records)))
+            if key == head(head(records))
             else assoc(key, tail(records)))
 def make_table():
     local_table = llist("*table*")

--- a/xml_py/chapter2/section5/subsection2.xml
+++ b/xml_py/chapter2/section5/subsection2.xml
@@ -226,8 +226,8 @@ def get_coercion(type1, type2):
         else:
             top = head(items)
             return (get_item(top)
-                    if equal(type1, get_type1(top)) and
-                       equal(type2, get_type2(top))
+                    if type1 == get_type1(top) and
+                       type2 == get_type2(top)
                     else get_coercion_iter(tail(items)))
     return get_coercion_iter(coercion_list)
       </PYTHON>
@@ -330,7 +330,7 @@ def assoc(key, records):
     return (None
             if is_none(records)
             else head(records)
-            if equal(key, head(head(records)))
+            if key == head(head(records))
             else assoc(key, tail(records)))
 def make_table():
     local_table = llist("*table*")
@@ -574,8 +574,8 @@ def get_coercion(type1, type2):
         else:
             top = head(items)
             return (get_item(top)
-                    if equal(type1, get_type1(top)) and
-                       equal(type2, get_type2(top))
+                    if type1 == get_type1(top) and
+                       type2 == get_type2(top)
                     else get_coercion_iter(tail(items)))
     return get_coercion_iter(coercion_list)
       </PYTHON>

--- a/xml_py/chapter3/section3/subsection3.xml
+++ b/xml_py/chapter3/section3/subsection3.xml
@@ -183,7 +183,7 @@ def assoc(key, records):
     return (None
             if is_none(records)
             else head(records)
-            if equal(key, head(head(records)))
+            if key == head(head(records))
             else assoc(key, tail(records)))
       </PYTHON>
     </SNIPPET>
@@ -356,7 +356,7 @@ def assoc(key, records):
     return (None
             if is_none(records)
             else head(records)
-            if equal(key, head(head(records)))
+            if key == head(head(records))
             else assoc(key, tail(records)))
       </PYTHON>
     </SNIPPET>

--- a/xml_py/chapter4/section4/subsection4.xml
+++ b/xml_py/chapter4/section4/subsection4.xml
@@ -1064,7 +1064,7 @@ def check_an_assertion(assertion, query_pat, query_frame):
 	</SCHEME>
 	<PYTHON>
 def pattern_match(pattern, data, frame):
-    return "failed" if frame == "failed" else frame if equal(pattern, data) else extend_if_consistent(pattern, data, frame) if is_variable(pattern) else pattern_match(tail(pattern), tail(data), pattern_match(head(pattern), head(data), frame)) if is_pair(pattern) and is_pair(data) else "failed"
+    return "failed" if frame == "failed" else frame if pattern == data else extend_if_consistent(pattern, data, frame) if is_variable(pattern) else pattern_match(tail(pattern), tail(data), pattern_match(head(pattern), head(data), frame)) if is_pair(pattern) and is_pair(data) else "failed"
 </PYTHON>
       </SNIPPET>
     </TEXT>
@@ -1560,7 +1560,7 @@ def rename_variables_in(rule):
 	</SCHEME>
 	<PYTHON>
 def unify_match(p1, p2, frame):
-    return "failed" if frame == "failed" else frame if equal(p1, p2) else extend_if_possible(p1, p2, frame) if is_variable(p1) else extend_if_possible(p2, p1, frame) if is_variable(p2) else unify_match(tail(p1), tail(p2), unify_match(head(p1), head(p2), frame)) if is_pair(p1) and is_pair(p2) else "failed"
+    return "failed" if frame == "failed" else frame if p1 == p2 else extend_if_possible(p1, p2, frame) if is_variable(p1) else extend_if_possible(p2, p1, frame) if is_variable(p2) else unify_match(tail(p1), tail(p2), unify_match(head(p1), head(p2), frame)) if is_pair(p1) and is_pair(p2) else "failed"
 </PYTHON>
       </SNIPPET>
     </TEXT>
@@ -1973,7 +1973,7 @@ def extend_if_possible(variable, value, frame):
 def depends_on(expression, variable, frame):
     def tree_walk(e):
         if is_variable(e):
-            if equal(variable, e):
+            if variable == e:
                 return True
             else:
                 b = binding_in_frame(e, frame)


### PR DESCRIPTION
## Summary
Fixes #1281. `equal(xs, ys)` is defined by the student in Exercise 2.54 (`chapter2/section3/subsection1.xml`) as a from-scratch structural equality check over pairs — it isn't a general-purpose primitive, and using it elsewhere in the book's own code implies a dependency that doesn't actually exist. Every other use is ordinary structural comparison, which Python's `==` already provides:

- `chapter2/section3/subsection3.xml`: `is_element_of_set`, `lookup`
- `chapter2/section3/subsection4.xml`: Huffman decode/encode round-trip check, `generate_huffman_tree` check
- `chapter2/section4/subsection3.xml`, `chapter2/section5/subsection2.xml`, `chapter3/section3/subsection3.xml`: `assoc` (association-list lookup, reused verbatim across these three), `get_coercion_iter`
- `chapter4/section4/subsection4.xml`: `pattern_match`, `unify_match`, `depends_on`'s `tree_walk` (the query-language pattern matcher/unifier)

(`greater_or_equal`, `number_equal`, and `is_equal` elsewhere are unrelated identifiers that happen to contain "equal" as a substring — not this function, left untouched.)

## Test plan
- [x] `SICP_EDITION=py yarn programs` regenerates cleanly
- [x] `yarn test:py`, compared against a stashed baseline to isolate any actual regression from this repo's existing pre-fix failures — chapters 3/4 unaffected
- [x] Chapter 2 shows 4 newly-failing **py-slang-only** tests (Huffman encode/decode round-trip, two message-passing/`assoc` dispatch examples); confirmed via `yarn test:py:cpython` that all 4 pass under CPython/the `sicp` reference library. This isn't a correctness problem with the fix — py-slang's `==` doesn't yet support comparing pair-based compound structures, only primitives, the same "reference library ahead of py-slang" gap as `is_number`. Tracked in a separate py-slang issue rather than blocking this content fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)