### PR TITLE
Fix Legend tooltip in navbar rendering off-screen

### DIFF
--- a/static/assets/stylesheet.css
+++ b/static/assets/stylesheet.css
@@ -13305,9 +13305,12 @@ span.comment {
   text-align: center;
   padding: 5px;
   border-radius: 6px;
- 
-  /* Position the tooltip text - see examples below! */
+
+  /* Position the tooltip text below the Legend button, right-aligned so it
+     stays on-screen (Legend sits at the far right edge of the navbar). */
   position: absolute;
+  top: 100%;
+  right: 0;
   z-index: 1;
 }
 


### PR DESCRIPTION
## Summary
- The Legend button in the top-right of the navbar (e.g. https://sicp.sourceacademy.org/chapters/4.2.html) opens a CSS-only hover/tap tooltip (`.toolttext`), but it had `position: absolute` with no `top`/`left`/`right` offsets.
- Since `.toolt` (the Legend span) sits at the far right edge of the fixed navbar, the tooltip's default static position placed its 140px-wide box starting right after the word "Legend" — spilling past the right edge of the viewport and rendering invisible without horizontal scrolling.
- Anchored the popup with `top: 100%; right: 0;` so it drops below the Legend button and stays right-aligned within the viewport.

## Test plan
- [ ] Load a chapter page (e.g. `chapters/4.2.html`) and hover/tap "Legend" in the top-right navbar; confirm the color-key box now appears fully on-screen just below the button.
- [ ] Check at a few viewport widths (mobile + desktop) that the popup doesn't get clipped or pushed off-screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)