### PR TITLE
Fix broken GPL 3 badge (dead GitHub camo proxy URL)

### DIFF
--- a/javascript/html/Licences.tsx
+++ b/javascript/html/Licences.tsx
@@ -24,10 +24,9 @@ const Licences: FC = () => {
     <div class="title-text-LICENCE">
       <a href="https://www.gnu.org/licenses/gpl-3.0.en.html" rel="nofollow"
         ><img
-          src="https://camo.githubusercontent.com/46d38fe6087a9b9bdf7e45458901b818765b8391/68747470733a2f2f75706c6f61642e77696b696d656469612e6f72672f77696b6970656469612f636f6d6d6f6e732f7468756d622f372f37392f4c6963656e73655f69636f6e2d67706c2e7376672f353070782d4c6963656e73655f69636f6e2d67706c2e7376672e706e67"
+          src="img_original/gpl-v3.svg"
           alt="GPL 3"
-          data-canonical-src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/79/License_icon-gpl.svg/50px-License_icon-gpl.svg.png"
-          style="max-width:100%;"
+          style="max-width:100%; width:50px;"
       /></a>
       <p />
       All Scheme programs in this work are licensed by Harold Abelson and Gerald


### PR DESCRIPTION
## Summary
- The GPL 3 badge shown on the license page of every edition (e.g. https://sicp.sourceacademy.org/split_py/, and the JS edition at the site root) is broken: it points at a `camo.githubusercontent.com` proxy URL, which returns **403** when loaded outside GitHub's own rendered pages. Its `data-canonical-src` fallback (an old Wikimedia Commons thumbnail) is also stale and returns **400**.
- The repo already bundles a proper `gpl-v3.svg` badge under `img_original/`, and it's already deployed at that path in every edition's build output (confirmed reachable at `.../split_py/img_original/gpl-v3.svg` and `.../img_original/gpl-v3.svg` on the JS edition).
- Since `Licences.tsx` is shared across all editions, this one change fixes the badge for the JS, Scheme, and Python builds.

## Test plan
- [x] Rebuilt the Python edition (`SICP_EDITION=py yarn split`) and confirmed `html_split_py/index.html` renders the new `img_original/gpl-v3.svg` source.
- [x] Rebuilt the JS edition (`SICP_EDITION=js yarn split`) and confirmed the same fix applies there.
- [x] Confirmed the referenced asset is already live and returns 200 (`image/svg+xml`) at both `sicp.sourceacademy.org/split_py/img_original/gpl-v3.svg` and `sicp.sourceacademy.org/img_original/gpl-v3.svg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)