### PR TITLE
Fix internal links hardcoded to /sicpjs/ regardless of edition

### DIFF
--- a/javascript/generateSearchData.ts
+++ b/javascript/generateSearchData.ts
@@ -464,7 +464,8 @@ const processTextFunctions = {
     obj["tag"] = "FOOTNOTE_REF";
     obj["id"] = `#footnote-link-${footnote_count}`;
     obj["body"] = `${footnote_count}`;
-    obj["href"] = `/sicpjs/${chapterIndex}#footnote-${footnote_count}`;
+    obj["href"] =
+      `/${edition.outputBaseName}/${chapterIndex}#footnote-${footnote_count}`;
   },
 
   DISPLAYFOOTNOTE: (node, obj) => {
@@ -474,7 +475,7 @@ const processTextFunctions = {
     obj["id"] = `#footnote-${display_footnote_count}`;
     obj["count"] = display_footnote_count;
     obj["href"] =
-      `/sicpjs/${chapterIndex}#footnote-link-${display_footnote_count}`;
+      `/${edition.outputBaseName}/${chapterIndex}#footnote-link-${display_footnote_count}`;
 
     recursiveProcessTextJson(node.firstChild, obj);
   },
@@ -857,11 +858,11 @@ export const generateSearchData = (doc, filename) => {
 
   // Add section title
   const title = {
-    id: `/sicpjs/${chapterIndex}`,
+    id: `/${edition.outputBaseName}/${chapterIndex}`,
     tag: "TITLE",
     body: displayTitle.trim()
   };
-  globalTitle = `/sicpjs/${chapterIndex}`;
+  globalTitle = `/${edition.outputBaseName}/${chapterIndex}`;
   //globaleE = chapArrIndex.charAt(0);
   arr.push(title);
 

--- a/javascript/generateTocJson.js
+++ b/javascript/generateTocJson.js
@@ -2,6 +2,7 @@ import fs from "fs";
 import path from "path";
 
 import { tableOfContent, allFilepath } from "./index.js";
+import { getEdition } from "./editions.js";
 
 // this should come from constants.js, but that
 // doesn't work, probably due to circular dependencies
@@ -126,7 +127,9 @@ export const createTocJson = outputDir => {
 
     for (const s in sitemap) {
       sitemapStream.write("  <url>\n    <loc>");
-      sitemapStream.write(sourceAcademyURL + "/sicpjs/");
+      sitemapStream.write(
+        sourceAcademyURL + "/" + getEdition().outputBaseName + "/"
+      );
       sitemapStream.write(sitemap[s]);
       const month = today.getMonth() + 1;
       const date = today.getDate();

--- a/javascript/parseXmlJson.js
+++ b/javascript/parseXmlJson.js
@@ -28,6 +28,7 @@ import { getEdition, getCompanionLanguage } from "./editions.js";
 // language for the Scheme edition).
 const lang = getEdition().language;
 const companion = getCompanionLanguage();
+const urlPrefix = getEdition().outputBaseName;
 
 let paragraph_count = 0;
 let heading_count = 0;
@@ -250,7 +251,7 @@ const processTextFunctions = {
     obj["tag"] = "FOOTNOTE_REF";
     obj["id"] = `#footnote-link-${footnote_count}`;
     obj["body"] = `${footnote_count}`;
-    obj["href"] = `/sicpjs/${chapterIndex}#footnote-${footnote_count}`;
+    obj["href"] = `/${urlPrefix}/${chapterIndex}#footnote-${footnote_count}`;
   },
 
   DISPLAYFOOTNOTE: (node, obj) => {
@@ -260,7 +261,7 @@ const processTextFunctions = {
     obj["id"] = `#footnote-${display_footnote_count}`;
     obj["count"] = display_footnote_count;
     obj["href"] =
-      `/sicpjs/${chapterIndex}#footnote-link-${display_footnote_count}`;
+      `/${urlPrefix}/${chapterIndex}#footnote-link-${display_footnote_count}`;
 
     recursiveProcessTextJson(node.firstChild, obj);
   },
@@ -590,7 +591,7 @@ export const parseXmlJson = (doc, arr, filename) => {
 
   // Add section title
   const title = {
-    id: `/sicpjs/${chapterIndex}`,
+    id: `/${urlPrefix}/${chapterIndex}`,
     tag: "TITLE",
     body: displayTitle.trim()
   };

--- a/javascript/processingFunctions/processReferenceJson.js
+++ b/javascript/processingFunctions/processReferenceJson.js
@@ -2,6 +2,9 @@ import { repeatedRefNameWarning, missingReferenceWarning } from "./warnings.js";
 import { tableOfContent } from "../index.js";
 import { tagsToRemove } from "../parseXmlJson";
 import { ancestorHasTag } from "../utilityFunctions";
+import { getEdition } from "../editions.js";
+
+const urlPrefix = getEdition().outputBaseName;
 
 export const referenceStore = {};
 
@@ -68,25 +71,25 @@ export const setupReferencesJson = (node, filename) => {
     let displayName;
     if (ref_type == "chap") {
       displayName = chapterIndex;
-      href = `/sicpjs/${chapterIndex}`;
+      href = `/${urlPrefix}/${chapterIndex}`;
     } else if (ref_type == "sec") {
       if (ancestorHasTag(label, "SUBSUBSECTION")) {
         subsubsection_count++;
         displayName = `${chapterIndex}.${subsubsection_count}`;
-        href = `/sicpjs/${chapterIndex}#subsubsection_${subsubsection_count}`;
+        href = `/${urlPrefix}/${chapterIndex}#subsubsection_${subsubsection_count}`;
       } else {
         displayName = chapterIndex;
-        href = `/sicpjs/${chapterIndex}`;
+        href = `/${urlPrefix}/${chapterIndex}`;
       }
     } else if (ref_type == "fig") {
       fig_count++;
       displayName = `${chapter_number}.${fig_count}`;
-      href = `/sicpjs/${chapterIndex}#fig-${displayName}`;
+      href = `/${urlPrefix}/${chapterIndex}#fig-${displayName}`;
     } else if (ref_type == "foot") {
       // Retrieve count from the parent node, setup before this loop
       foot_count = label.parentNode.footnote_count;
       displayName = foot_count;
-      href = `/sicpjs/${chapterIndex}#footnote-${foot_count}`;
+      href = `/${urlPrefix}/${chapterIndex}#footnote-${foot_count}`;
     } else {
       continue;
     }
@@ -130,7 +133,7 @@ export const setupReferencesJson = (node, filename) => {
 
     ex_count++;
     const displayName = `${chapter_number}.${ex_count}`;
-    const href = `/sicpjs/${chapterIndex}#ex-${displayName}`;
+    const href = `/${urlPrefix}/${chapterIndex}#ex-${displayName}`;
     referenceStore[referenceName] = { href, displayName, chapterIndex };
 
     // An exercise may carry more than one label (e.g. a semantic label

--- a/javascript/searchRewrite.ts
+++ b/javascript/searchRewrite.ts
@@ -9,7 +9,7 @@ const lang = getEdition().language;
 // line 3 to 68: trie implementation and search functions
 
 export const getUrl = searchResult =>
-  `https://sourceacademy.nus.edu.sg/sicpjs/${searchResult.id}`;
+  `https://sourceacademy.nus.edu.sg/${getEdition().outputBaseName}/${searchResult.id}`;
 
 // search data, maintaining and updation functions and write function from this line onwards
 export const idToContentMap: Record<string, string> = {};


### PR DESCRIPTION
Fixes #1279

## Summary
- The reported symptom was footnote links on the SICPy site going to the SICP JS edition instead of staying on SICPy. Root cause: several places that build internal hrefs (chapter/section/figure/footnote/exercise cross-references, the sitemap, and search results) hardcoded the `/sicpjs/` URL prefix rather than deriving it from the edition being built.
- This affected every edition other than JS: the Python edition would link into `/sicpjs/...`, and the Scheme edition (whose correct prefix is `/sicp/`) had the same problem.
- Fixed by using `getEdition().outputBaseName` (already defined per-edition in `editions.ts`, e.g. `"sicpy"` for Python, `"sicp"` for Scheme) instead of the literal string, in:
  - `javascript/processingFunctions/processReferenceJson.js` — chapter/section/figure/footnote/exercise `<REF>` hrefs
  - `javascript/parseXmlJson.js` — footnote-marker and footnote-anchor hrefs, and the per-chapter title id
  - `javascript/generateSearchData.ts` — same, for the search index
  - `javascript/searchRewrite.ts` — search result URL rewriting
  - `javascript/generateTocJson.js` — sitemap.xml entries

## Test plan
- [x] Rebuilt `json_py` from scratch (`SICP_EDITION=py yarn json`) and confirmed chapter/footnote/figure/exercise links in the generated chapter JSON (e.g. `3.3.5.json`) now point at `/sicpy/...`, and `sitemap.xml` lists `sourceacademy.org/sicpy/...` URLs.
- [x] Rebuilt `json_js` from scratch and confirmed no regression — links still correctly point at `/sicpjs/...`.
- [x] Rebuilt `json_scm` from scratch and confirmed it now also correctly points at `/sicp/...` (previously also broken, just not reported).
- [x] `npx prettier --list-different` clean on all changed files.

## Note
While investigating, I also noticed `javascript/versions/split.tsx` hardcodes an "Interactive SICP JS" link and a "Scheme/JS" title on the comparison-edition page regardless of which edition is being built. That's a separate (cosmetic, not link-breaking) issue — left out of this PR to keep it scoped to #1279, happy to file/fix separately if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)