### PR TITLE
Fix GPL 3 logo invisible on dark backgrounds

### DIFF
--- a/static/img_original/gpl-v3.svg
+++ b/static/img_original/gpl-v3.svg
@@ -56,6 +56,13 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <rect
+     id="background"
+     x="0"
+     y="0"
+     width="750"
+     height="300"
+     fill="#ffffff" />
   <g
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"


### PR DESCRIPTION
## Summary
The `gpl-v3.svg` logo used for the GPL badge (added in #1299 for the site, #1302 for the README) is invisible on dark backgrounds — its artwork is pure black (`fill:#000000` / `stroke:#000000`) with no background, so on a dark page/theme (e.g. GitHub dark mode) it's just black-on-black.

Fixed by adding a solid white background rect behind the artwork, matching the white canvas it was originally designed against (`pagecolor="#ffffff"` in the file's own Inkscape metadata) and the same opaque-background approach the neighboring CC-BY-SA badge already uses (that one's a PNG, so it was never transparent to begin with).

This is the single tracked source file (`static/img_original/gpl-v3.svg`); the copies under `html_split_py/`, `html_split_js/`, and `html_scheme_py/` are generated build output, not source, so nothing else needs to change.

## Test plan
- [x] Rendered the SVG to PNG (`rsvg-convert`) and composited it onto both black and white backgrounds — the badge is fully visible on both (previously invisible on black).
- [x] Confirmed the top-left pixel of the rendered image is now fully opaque white (255,255,255,255), vs. previously transparent.
- [x] Validated the edited SVG is still well-formed XML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)