### PR TITLE
Fix print/error argument order in SICPy

### DIFF
--- a/xml_py/chapter2/section1/subsection3.xml
+++ b/xml_py/chapter2/section1/subsection3.xml
@@ -312,7 +312,7 @@ def pair(x, y):
     def dispatch(m):
         return (x if m == 0
                 else y if m == 1
-                else error(m, "argument not 0 or 1 -- pair"))
+                else error("argument not 0 or 1 -- pair", m))
     return dispatch
 def head(z): return z(0)
 <SHORT_SPACE/>

--- a/xml_py/chapter2/section3/subsection2.xml
+++ b/xml_py/chapter2/section3/subsection2.xml
@@ -319,7 +319,7 @@ def deriv(exp, variable):
                                              variable),
                                        multiplicand(exp)))
             if is_product(exp)
-            else error(exp, "unknown expression type -- deriv"))
+            else error("unknown expression type -- deriv", exp))
       </PYTHON>
     </SNIPPET>
     This <SCHEMEINLINE>deriv</SCHEMEINLINE>
@@ -938,7 +938,7 @@ def deriv(exp, variable):
                           make_product(deriv(multiplier(exp), variable),
                                        multiplicand(exp)))
             if is_product(exp)
-            else error(exp, "unknown expression type -- deriv"))
+            else error("unknown expression type -- deriv", exp))
       </PYTHON>
     </SNIPPET>
     Here is how this version works on our three examples:
@@ -1090,7 +1090,7 @@ def deriv(exp, variable):
                                                     exponent(exp) - 1)),
                               deriv(base(exp), variable))
             if is_exp(exp)
-            else error(exp, "unknown expression type -- deriv"))
+            else error("unknown expression type -- deriv", exp))
 	</PYTHON>
 	<SCHEME>
 	</SCHEME>
@@ -1160,7 +1160,7 @@ def deriv(exp, variable):
                           make_product(deriv(multiplier(exp), variable),
                                        multiplicand(exp)))
             if is_product(exp)
-            else error(exp, "unknown expression type -- deriv"))
+            else error("unknown expression type -- deriv", exp))
       </PYTHON>
     </SNIPPET>
     <SNIPPET>
@@ -1277,7 +1277,7 @@ function deriv(exp, variable) {
                             make_product(deriv(multiplier(exp),
                                                variable),
                                          multiplicand(exp)))
-                 : error(exp, "unknown expression type -- deriv");
+                 : error("unknown expression type -- deriv", exp);
 }
 	</PYTHON>
       </SNIPPET>
@@ -1425,7 +1425,7 @@ def deriv(exp, variable):
                           make_product(deriv(multiplier(exp), variable),
                                        multiplicand(exp)))
             if is_product(exp)
-            else error(exp, "unknown expression type -- deriv"))
+            else error("unknown expression type -- deriv", exp))
 	    </PYTHON>
 	    <SCHEME>
 	    </SCHEME>
@@ -1512,7 +1512,7 @@ def deriv(exp, variable):
                           make_product(deriv(multiplier(exp), variable),
                                        multiplicand(exp)))
             if is_product(exp)
-            else error(exp, "unknown expression type -- deriv"))
+            else error("unknown expression type -- deriv", exp))
 	    </PYTHON>
 	    <SCHEME>
 	    </SCHEME>

--- a/xml_py/chapter2/section3/subsection2.xml
+++ b/xml_py/chapter2/section3/subsection2.xml
@@ -1277,7 +1277,7 @@ function deriv(exp, variable) {
                             make_product(deriv(multiplier(exp),
                                                variable),
                                          multiplicand(exp)))
-                 : error("unknown expression type -- deriv", exp);
+                 : error(exp, "unknown expression type -- deriv");
 }
 	</PYTHON>
       </SNIPPET>

--- a/xml_py/chapter2/section3/subsection4.xml
+++ b/xml_py/chapter2/section3/subsection4.xml
@@ -614,7 +614,7 @@ def choose_branch(bit, branch):
             if bit == 0
             else right_branch(branch)
             if bit == 1
-            else error(bit, "bad bit -- choose_branch"))
+            else error("bad bit -- choose_branch", bit))
       </PYTHON>
     </SNIPPET>
     <SNIPPET HIDE="yes">

--- a/xml_py/chapter2/section4/subsection2.xml
+++ b/xml_py/chapter2/section4/subsection2.xml
@@ -102,11 +102,11 @@ def attach_tag(type_tag, contents):
 def type_tag(datum):
     return (head(datum)
             if is_pair(datum)
-            else error(datum, "bad tagged datum -- type_tag"))
+            else error("bad tagged datum -- type_tag", datum))
 def contents(datum):
     return (tail(datum)
             if is_pair(datum)
-            else error(datum, "bad tagged datum -- contents"))
+            else error("bad tagged datum -- contents", datum))
       </PYTHON>
     </SNIPPET>
     <SNIPPET HIDE="yes">
@@ -384,25 +384,25 @@ def real_part(z):
             if is_rectangular(z)
             else real_part_polar(contents(z))
             if is_polar(z)
-            else error(z, "unknown type -- real_part"))
+            else error("unknown type -- real_part", z))
 def imag_part(z):
     return (imag_part_rectangular(contents(z))
             if is_rectangular(z)
             else imag_part_polar(contents(z))
             if is_polar(z)
-            else error(z, "unknown type -- imag_part"))
+            else error("unknown type -- imag_part", z))
 def magnitude(z):
     return (magnitude_rectangular(contents(z))
             if is_rectangular(z)
             else magnitude_polar(contents(z))
             if is_polar(z)
-            else error(z, "unknown type -- magnitude"))
+            else error("unknown type -- magnitude", z))
 def angle(z):
     return (angle_rectangular(contents(z))
             if is_rectangular(z)
             else angle_polar(contents(z))
             if is_polar(z)
-            else error(z, "unknown type -- angle"))
+            else error("unknown type -- angle", z))
       </PYTHON>
     </SNIPPET>
     <SNIPPET HIDE="yes">

--- a/xml_py/chapter2/section4/subsection3.xml
+++ b/xml_py/chapter2/section4/subsection3.xml
@@ -684,8 +684,8 @@ def apply_generic(op, args):
     fun = get(op, type_tags)
     return (apply_in_underlying_javascript(fun, map(contents, args))
             if not is_none(fun)
-            else error(llist(op, type_tags),
-                       "no method for these types -- apply_generic"))
+            else error("no method for these types -- apply_generic",
+                       llist(op, type_tags)))
       </PYTHON>
     </SNIPPET>
     Using
@@ -819,7 +819,7 @@ def deriv(exp, variable):
                                        multiplicand(exp)))
             if is_product(exp)
             # more rules can be added here
-            else error(exp, "unknown expression type -- deriv"))
+            else error("unknown expression type -- deriv", exp))
       </PYTHON>
     </SNIPPET>
     <SNIPPET>
@@ -1553,7 +1553,7 @@ def make_from_real_imag(x, y):
                 if op == "magnitude"
                 else math_atan2(y, x)
                 if op == "angle"
-                else error(op, "unknown op -- make_from_real_imag"))
+                else error("unknown op -- make_from_real_imag", op))
     return dispatch
       </PYTHON>
       <PYTHON_RUN>
@@ -1567,7 +1567,7 @@ def make_from_real_imag(x, y):
                 if op == "magnitude"
                 else math_atan2(y, x)
                 if op == "angle"
-                else error(op, "unknown op -- make_from_real_imag"))
+                else error("unknown op -- make_from_real_imag", op))
     return dispatch
 
 def make_from_mag_ang(r, a):
@@ -1580,7 +1580,7 @@ def make_from_mag_ang(r, a):
                 if op == "magnitude"
                 else a
                 if op == "angle"
-                else error(op, "unknown op -- make_from_real_imag"))
+                else error("unknown op -- make_from_real_imag", op))
     return dispatch
 
 def apply_generic(op, arg):
@@ -1657,11 +1657,11 @@ def attach_tag(type_tag, contents):
 def type_tag(datum):
     return (head(datum)
             if is_pair(datum)
-            else error(datum, "bad tagged datum -- type_tag"))
+            else error("bad tagged datum -- type_tag", datum))
 def contents(datum):
     return (tail(datum)
             if is_pair(datum)
-            else error(datum, "bad tagged datum -- contents"))
+            else error("bad tagged datum -- contents", datum))
 def install_rectangular_package():
     def real_part(z): return head(z)
     def imag_part(z): return tail(z)
@@ -1884,7 +1884,7 @@ def make_from_mag_ang(r, a):
                 if op == "magnitude"
                 else a
                 if op == "angle"
-                else error(op, "unknown op -- make_from_real_imag"))
+                else error("unknown op -- make_from_real_imag", op))
     return dispatch
         </PYTHON>
 	<PYTHON_RUN>

--- a/xml_py/chapter2/section5/subsection1.xml
+++ b/xml_py/chapter2/section5/subsection1.xml
@@ -871,13 +871,13 @@ def type_tag(datum):
             if is_number(datum)
             else head(datum)
             if is_pair(datum)
-            else error(datum, "bad tagged datum -- type_tag"))
+            else error("bad tagged datum -- type_tag", datum))
 def contents(datum):
     return (datum
             if is_number(datum)
             else tail(datum)
             if is_pair(datum)
-            else error(datum, "bad tagged datum -- contents"))
+            else error("bad tagged datum -- contents", datum))
         </PYTHON>
         <SCHEME>
 (define (attach-tag type-tag contents) 

--- a/xml_py/chapter2/section5/subsection2.xml
+++ b/xml_py/chapter2/section5/subsection2.xml
@@ -390,11 +390,11 @@ def attach_tag(type_tag, contents):
 def type_tag(datum):
     return (head(datum)
             if is_pair(datum)
-            else error(datum, "bad tagged datum -- type_tag"))
+            else error("bad tagged datum -- type_tag", datum))
 def contents(datum):
     return (tail(datum)
             if is_pair(datum)
-            else error(datum, "bad tagged datum -- contents"))
+            else error("bad tagged datum -- contents", datum))
 </PYTHON>
     </SNIPPET>
     <SNIPPET HIDE="yes">
@@ -646,11 +646,11 @@ def apply_generic(op, args):
                     if not is_none(t1_to_t2)
                     else apply_generic(op, llist(a1, t2_to_t1(a2)))
                     if not is_none(t2_to_t1)
-                    else error(llist(op, type_tags),
-                               "no method for these types"))
+                    else error("no method for these types",
+                               llist(op, type_tags)))
         else:
-            return error(llist(op, type_tags),
-                         "no method for these types")
+            return error("no method for these types",
+                         llist(op, type_tags))
       </PYTHON>
     </SNIPPET>
   </TEXT>
@@ -1130,18 +1130,18 @@ def apply_generic(op, args):
             a2 = head(tail(args))
             t1_to_t2 = get_coercion(type1, type2)
             t2_to_t1 = get_coercion(type2, type1)
-            return (error(llist(op, type_tags),
-                          "no method for these types")
+            return (error("no method for these types",
+                          llist(op, type_tags))
                     if type1 == type2
                     else apply_generic(op, llist(t1_to_t2(a1), a2))
                     if not is_none(t1_to_t2)
                     else apply_generic(op, llist(a1, t2_to_t1(a2)))
                     if not is_none(t2_to_t1)
-                    else error(llist(op, type_tags),
-                               "no method for these types"))
+                    else error("no method for these types",
+                               llist(op, type_tags)))
         else:
-            return error(llist(op, type_tags),
-                         "no method for these types")
+            return error("no method for these types",
+                         llist(op, type_tags))
       </PYTHON>
     </SNIPPET>
     </LI>
@@ -1237,8 +1237,8 @@ def apply_generic(op, args):
                          True, type_tags)):
             return apply_generic(op, coerce_all(args, target_type))
         else:
-            return error(llist(op, type_tags),
-                         "no method for these types")
+            return error("no method for these types",
+                         llist(op, type_tags))
         </PYTHON>
       </SNIPPET>
     A situation where this approach is not sufficient is if you have three

--- a/xml_py/chapter2/section5/subsection3.xml
+++ b/xml_py/chapter2/section5/subsection3.xml
@@ -191,12 +191,12 @@ def add_poly(p1, p2):
     return (make_poly(variable(p1),
                       add_terms(term_list(p1), term_list(p2)))
             if is_same_variable(variable(p1), variable(p2))
-            else error(llist(p1, p2), "polys not in same var -- add_poly"))
+            else error("polys not in same var -- add_poly", llist(p1, p2)))
 def mul_poly(p1, p2):
     return (make_poly(variable(p1),
                       mul_terms(term_list(p1), term_list(p2)))
             if is_same_variable(variable(p1), variable(p2))
-            else error(llist(p1, p2), "polys not in same var -- mul_poly"))
+            else error("polys not in same var -- mul_poly", llist(p1, p2)))
       </PYTHON>
     </SNIPPET>
   </TEXT>
@@ -865,8 +865,8 @@ def install_polynomial_package():
                           add_terms(term_list(p1),
                                     term_list(p2)))
                 if is_same_variable(variable(p1), variable(p2))
-                else error(llist(p1, p2),
-                           "polys not in same var -- add_poly"))
+                else error("polys not in same var -- add_poly",
+                           llist(p1, p2)))
 
     def add_terms(L1, L2):
         if is_empty_termlist(L1):
@@ -891,8 +891,8 @@ def install_polynomial_package():
                           mul_terms(term_list(p1),
                                     term_list(p2)))
                 if is_same_variable(variable(p1), variable(p2))
-                else error(llist(p1, p2),
-                           "polys not in same var -- mul_poly"))
+                else error("polys not in same var -- mul_poly",
+                           llist(p1, p2)))
 
     def mul_terms(L1, L2):
         return (the_empty_termlist
@@ -1016,7 +1016,7 @@ def sub_poly(p1, p2):
     return (make_poly(variable(p1),
                       sub_terms(term_list(p1), term_list(p2)))
             if is_same_variable(variable(p1), variable(p2))
-            else error(llist(p1, p2), "polys not in same var -- sub_poly"))
+            else error("polys not in same var -- sub_poly", llist(p1, p2)))
 	</PYTHON>
       </SNIPPET>
     </SOLUTION>

--- a/xml_py/chapter3/section1/subsection1.xml
+++ b/xml_py/chapter3/section1/subsection1.xml
@@ -869,7 +869,7 @@ def make_account(balance):
     def dispatch(m):
         return (withdraw if m == "withdraw"
                 else deposit if m == "deposit"
-                else error(m, "unknown request -- make_account"))
+                else error("unknown request -- make_account", m))
     return dispatch
       </PYTHON>
     </SNIPPET>

--- a/xml_py/chapter3/section2/subsection4.xml
+++ b/xml_py/chapter3/section2/subsection4.xml
@@ -519,7 +519,7 @@ def make_account(balance):
     def dispatch(m):
         return (withdraw if m == "withdraw"
                 else deposit if m == "deposit"
-                else error(m, "Unknown request: make_account"))
+                else error("Unknown request: make_account", m))
     return dispatch
       </PYTHON>
     </SNIPPET>

--- a/xml_py/chapter3/section3/subsection1.xml
+++ b/xml_py/chapter3/section3/subsection1.xml
@@ -1762,7 +1762,7 @@ def pair(x, y):
                 if m == "head"
                 else y
                 if m == "tail"
-                else error(m, "undefined operation -- pair"))
+                else error("undefined operation -- pair", m))
     return dispatch
 <SHORT_SPACE/>
 def head(z):
@@ -1852,7 +1852,7 @@ def pair(x, y):
                       if m == "set_head"
                       else set_y
                       if m == "set_tail"
-                      else error(m, "undefined operation -- pair"))
+                      else error("undefined operation -- pair", m))
 <SHORT_SPACE_AND_ALLOW_BREAK/>
 def head(z):
     return z("head")

--- a/xml_py/chapter3/section3/subsection2.xml
+++ b/xml_py/chapter3/section3/subsection2.xml
@@ -445,7 +445,7 @@ print(front_queue(q))
       </SCHEME>
       <PYTHON>
 def front_queue(queue):
-    return (error(queue, "front_queue called with an empty queue")
+    return (error("front_queue called with an empty queue", queue)
             if is_empty_queue(queue)
             else head(front_ptr(queue)))
       </PYTHON>
@@ -608,7 +608,7 @@ def insert_queue(queue, item):
       <PYTHON>
 def delete_queue(queue):
     if is_empty_queue(queue):
-        error(queue, "delete_queue called with an empty queue")
+        error("delete_queue called with an empty queue", queue)
     else:
         set_front_ptr(queue, tail(front_ptr(queue)))
         return queue
@@ -845,7 +845,7 @@ def make_queue():
                 else delete_queue if m == "delete_queue"
                 else is_empty_queue if m == "is_empty_queue"
                 else print_queue if m == "print_queue"
-                else error(m, "Unknown operation -- DISPATCH"))
+                else error("Unknown operation -- DISPATCH", m))
     return dispatch
 
 def insert_queue(queue, item):
@@ -982,7 +982,7 @@ def front_insert_deque(deque, item):
 
 def front_delete_deque(deque):
     if is_empty_deque(deque):
-        error(deque, "front_delete_deque called with an empty deque")
+        error("front_delete_deque called with an empty deque", deque)
     elif is_one_item_deque(deque):
         set_front_ptr(deque, None)
         set_rear_ptr(deque, None)
@@ -1004,7 +1004,7 @@ def rear_insert_deque(deque, item):
 
 def rear_delete_deque(deque):
     if is_empty_deque(deque):
-        error(deque, "rear_delete_deque called with an empty deque")
+        error("rear_delete_deque called with an empty deque", deque)
     elif is_one_item_deque(deque):
         set_front_ptr(deque, None)
         set_rear_ptr(deque, None)

--- a/xml_py/chapter3/section3/subsection3.xml
+++ b/xml_py/chapter3/section3/subsection3.xml
@@ -537,7 +537,7 @@ def make_table():
     def dispatch(m):
         return (lookup if m == "lookup"
                 else insert if m == "insert"
-                else error(m, "unknown operation -- table"))
+                else error("unknown operation -- table", m))
     return dispatch
       </PYTHON>
     </SNIPPET>
@@ -674,7 +674,7 @@ def make_table(same_key):
     def dispatch(m):
         return (lookup if m == "lookup"
                 else insert if m == "insert"
-                else error(m, "unknow operation -- table"))
+                else error("unknow operation -- table", m))
     return dispatch
 
 operation_table = make_table(lambda a, b: a == b)
@@ -776,7 +776,7 @@ def make_table(same_key):
         return (lookup if m == "lookup"
                 else insert if m == "insert"
                 else (lambda: display(local_table)) if m == "show"
-                else error(m, "unknow operation -- table"))
+                else error("unknow operation -- table", m))
     return dispatch
 
 table = make_table(equal)
@@ -884,7 +884,7 @@ def make_table():
         return (get if m == "lookup"
                 else insert if m == "insert"
                 else print if m == "print"
-                else error(m, "error"))
+                else error("error", m))
     return dispatch
 	</PYTHON>
       </SNIPPET>

--- a/xml_py/chapter3/section3/subsection4.xml
+++ b/xml_py/chapter3/section3/subsection4.xml
@@ -547,7 +547,7 @@ def logical_not(s):
             if s == 0
             else 0
             if s == 1
-            else error(s, "invalid signal"))
+            else error("invalid signal", s))
       </PYTHON>
     </SNIPPET>
   </TEXT>
@@ -560,9 +560,9 @@ def logical_and(s1, s2):
             if s1 == 1 and s2 == 1
             else (0
                   if s2 == 0 or s2 == 1
-                  else error(s2, "invalid signal"))
+                  else error("invalid signal", s2))
             if s1 == 0 or s1 == 1
-            else error(s1, "invalid signal"))
+            else error("invalid signal", s1))
     </PYTHON>
   </SNIPPET>
   <PDF_ONLY>
@@ -663,9 +663,9 @@ def logical_or(s1, s2):
             if s1 == 0 and s2 == 0
             else (1
                   if s2 == 0 or s2 == 1
-                  else error(s2, "invalid signal"))
+                  else error("invalid signal", s2))
             if s1 == 0 or s1 == 1
-            else error(s1, "invalid signal"))
+            else error("invalid signal", s1))
 	</PYTHON>
       </SNIPPET>
       <SNIPPET>
@@ -886,7 +886,7 @@ def make_wire():
         return (signal_value if m == "get_signal"
                 else set_my_signal if m == "set_signal"
                 else accept_action_function if m == "add_action"
-                else error(m, "unknown operation -- wire"))
+                else error("unknown operation -- wire", m))
     return dispatch
       </PYTHON>
     </SNIPPET>

--- a/xml_py/chapter3/section3/subsection5.xml
+++ b/xml_py/chapter3/section3/subsection5.xml
@@ -605,7 +605,7 @@ def adder(a1, a2, sum):
         elif request == "I lost my value.":
             process_forget_value()
         else:
-            error(request, "unknown request -- adder")
+            error("unknown request -- adder", request)
     connect(a1, me)
     connect(a2, me)
     connect(sum, me)
@@ -765,7 +765,7 @@ def multiplier(m1, m2, product):
         elif request == "I lost my value.":
             process_forget_value()
         else:
-            error(request, "unknown request -- multiplier")
+            error("unknown request -- multiplier", request)
     connect(m1, me)
     connect(m2, me)
     connect(product, me)
@@ -807,7 +807,7 @@ def multiplier(m1, m2, product):
       <PYTHON>
 def constant(value, connector):
     def me(request):
-        error(request, "unknown request -- constant")
+        error("unknown request -- constant", request)
     connect(connector, me)
     set_value(connector, value, me)
     return me
@@ -863,7 +863,7 @@ def probe(name, connector):
                 if request == "I have a value."
                 else process_forget_value()
                 if request == "I lost my value."
-                else error(request, "unknown request -- probe"))
+                else error("unknown request -- probe", request))
     connect(connector, me)
     return me
       </PYTHON>
@@ -941,7 +941,7 @@ def make_connector():
                                    inform_about_value,
                                    constraints)
         elif value != newval:
-            error(llist(value, newval), "contradiction")
+            error("contradiction", llist(value, newval))
         else:
             return "ignored"
     def forget_my_value(retractor):
@@ -976,7 +976,7 @@ def make_connector():
         elif request == "connect":
             return connect
         else:
-            error(request, "unknown operation -- connector")
+            error("unknown operation -- connector", request)
     return me
       </PYTHON>
     </SNIPPET>
@@ -1284,7 +1284,7 @@ def squarer(a, b):
     def process_new_value():
         if has_value(b):
             if get_value(b) &lt; 0:
-                error(get_value(b), "square less than 0 -- squarer")
+                error("square less than 0 -- squarer", get_value(b))
             else:
                 <META>alternative_1</META>
         else:
@@ -1322,7 +1322,7 @@ def squarer(a, b):
     def process_new_value():
         if has_value(b):
             if get_value(b) &lt; 0:
-                error(get_value(b), "square less than 0 -- squarer")
+                error("square less than 0 -- squarer", get_value(b))
             else:
                 set_value(a, math_sqrt(get_value(b)), me)
         else:
@@ -1338,7 +1338,7 @@ def squarer(a, b):
         elif request == "I lost my value.":
             process_forget_value()
         else:
-            error(request, "unknown request -- squarer")
+            error("unknown request -- squarer", request)
     connect(a, me)
     connect(b, me)
     return me

--- a/xml_py/chapter3/section4/subsection2.xml
+++ b/xml_py/chapter3/section4/subsection2.xml
@@ -489,7 +489,7 @@ def make_account(balance):
         return (protect(withdraw) if m == "withdraw"
                 else protect(deposit) if m == "deposit"
                 else balance if m == "balance"
-                else error(m, "unknown request -- make_account"))
+                else error("unknown request -- make_account", m))
     return dispatch
       </PYTHON>
     </SNIPPET>
@@ -649,7 +649,7 @@ def make_account(balance):
         return (protect(withdraw) if m == "withdraw"
                 else protect(deposit) if m == "deposit"
                 else protect(lambda: balance)() if m == "balance"  # serialized
-                else error(m, "unknown request -- make_account"))
+                else error("unknown request -- make_account", m))
     return dispatch
       </PYTHON>
     </SNIPPET>
@@ -738,7 +738,7 @@ def make_account(balance):
         return (protect_withdraw if m == "withdraw"
                 else protect_deposit if m == "deposit"
                 else balance if m == "balance"
-                else error(m, "unknown request -- make_account"))
+                else error("unknown request -- make_account", m))
     return dispatch
       </PYTHON>            
     </SNIPPET>
@@ -928,7 +928,7 @@ def make_account_and_serializer(balance):
                       else deposit if m == "deposit"
                       else balance if m == "balance"
                       else balance_serializer if m == "serializer"
-                      else error(m, "unknown request -- make_account"))
+                      else error("unknown request -- make_account", m))
       </PYTHON>
     </SNIPPET>
   </TEXT>
@@ -1195,7 +1195,7 @@ def make_account_and_serializer(balance):
                       else balance_serializer(deposit) if m == "deposit"
                       else balance if m == "balance"
                       else balance_serializer if m == "serializer"
-                      else error(m, "unknown request -- make_account"))
+                      else error("unknown request -- make_account", m))
       </PYTHON>
     </SNIPPET>
     Then deposits are handled as with the original
@@ -1454,7 +1454,7 @@ def make_mutex():
                  else True)
                 if m == "acquire"
                 else clear(cell) if m == "release"
-                else error(m, "unknown request -- mutex"))
+                else error("unknown request -- mutex", m))
     return the_mutex
 
 def clear(cell):

--- a/xml_py/chapter3/section5/subsection1.xml
+++ b/xml_py/chapter3/section5/subsection1.xml
@@ -1380,7 +1380,7 @@ def stream_map_2(f, s1, s2):
 def stream_map_2(f, s1, s2):
     return (None
             if is_none(s1) and is_none(s2)
-            else error(None, "unexpected argument -- stream_map_2")
+            else error("unexpected argument -- stream_map_2", None)
             if is_none(s1) or is_none(s2)
             else pair(f(head(s1), head(s2)),
                       memo(lambda: stream_map_2(f, stream_tail(s1),

--- a/xml_py/chapter3/section5/subsection4.xml
+++ b/xml_py/chapter3/section5/subsection4.xml
@@ -353,7 +353,7 @@ def memo(fun):
 def stream_combine(f, s1, s2):
     return (None
             if is_none(s1) and is_none(s2)
-            else error(None, "unexpected argument -- stream_combine")
+            else error("unexpected argument -- stream_combine", None)
             if is_none(s1) or is_none(s2)
             else pair(f(head(s1), head(s2)),
                       memo(lambda: stream_combine(f, stream_tail(s1),

--- a/xml_py/chapter4/section1/subsection1.xml
+++ b/xml_py/chapter4/section1/subsection1.xml
@@ -394,7 +394,7 @@ def evaluate(component, env):
     return evaluate(function_def_to_assignment(component), env)
   elif is_assignment(component):
     return eval_assignment(component, env)
-  else:	return error(component, "unknown syntax -- evaluate")
+  else:	return error("unknown syntax -- evaluate", component)
 	  </PYTHON>
 	</SNIPPET>
 	<SNIPPET PAGE="365" HIDE="yes">
@@ -609,7 +609,7 @@ def apply(fun, arguments):
                 if is_return_value(result)
                 else None)
     else:
-        return error(fun, "unknown function type -- apply")
+        return error("unknown function type -- apply", fun)
       </PYTHON>
     </SNIPPET>
     <SNIPPET PAGE="366" HIDE="yes">

--- a/xml_py/chapter4/section1/subsection2.xml
+++ b/xml_py/chapter4/section1/subsection2.xml
@@ -2074,7 +2074,7 @@ def second_expression(component):
     return head(tail(tail(tail(component))))
 def logical_comp_decl_to_conditional_expr_decl(component):
     operation = logical_operation(component)
-    return make_conditional_expr_decl( first_expression(component), second_expression(component), False ) if operation == "&amp;&amp;" else make_conditional_expr_decl( first_expression(component), True, second_expression(component) ) if operation == "||" else error(component, "unknown operation -- logical_comp_decl_to_conditional_expr_decl")
+    return make_conditional_expr_decl( first_expression(component), second_expression(component), False ) if operation == "&amp;&amp;" else make_conditional_expr_decl( first_expression(component), True, second_expression(component) ) if operation == "||" else error("unknown operation -- logical_comp_decl_to_conditional_expr_decl", component)
 print(logical_comp_decl_to_conditional_expr_decl(parse("a &amp;&amp; b;")))
 print(logical_comp_decl_to_conditional_expr_decl(parse("a || b;")))
 print(logical_comp_decl_to_conditional_expr_decl(parse("(a &amp;&amp; !b) || (!a &amp;&amp; b);")))

--- a/xml_py/chapter4/section1/subsection3.xml
+++ b/xml_py/chapter4/section1/subsection3.xml
@@ -108,7 +108,7 @@ def is_falsy(x):
       </SCHEME>
       <PYTHON>
 def is_truthy(x):
-    return x if is_boolean(x) else error(x, "boolean expected, received")
+    return x if is_boolean(x) else error("boolean expected, received", x)
 def is_falsy(x):
     return not is_truthy(x)
 </PYTHON>
@@ -580,7 +580,7 @@ def frame_values(frame):
       </SCHEME>
       <PYTHON>
 def extend_environment(symbols, vals, base_env):
-    return pair(make_frame(symbols, vals), base_env) if length(symbols) == length(vals) else error(pair(symbols, vals), "too many arguments supplied" if length(symbols) &lt; length(vals) else "too few arguments supplied")
+    return pair(make_frame(symbols, vals), base_env) if length(symbols) == length(vals) else error("too many arguments supplied" if length(symbols) &lt; length(vals) else "too few arguments supplied", pair(symbols, vals))
 </PYTHON>
       <PYTHON_RUN>
 def extend_environment(symbols, vals, base_env):
@@ -674,7 +674,7 @@ def lookup_symbol_value(symbol, env):
         def scan(symbols, vals):
             return env_loop(enclosing_environment(env)) if is_none(symbols) else head(vals) if symbol == head(symbols) else scan(tail(symbols), tail(vals))
         if env == the_empty_environment:
-            error(symbol, "unbound name")
+            error("unbound name", symbol)
         else:
             frame = first_frame(env)
             return scan(frame_symbols(frame), frame_values(frame))
@@ -737,7 +737,7 @@ def assign_symbol_value(symbol, val, env):
         def scan(symbols, vals):
             return env_loop(enclosing_environment(env)) if is_none(symbols) else set_head(vals, val) if symbol == head(symbols) else scan(tail(symbols), tail(vals))
         if env == the_empty_environment:
-            error(symbol, "unbound name -- assignment")
+            error("unbound name -- assignment", symbol)
         else:
             frame = first_frame(env)
             return scan(frame_symbols(frame), frame_values(frame))

--- a/xml_py/chapter4/section1/subsection4.xml
+++ b/xml_py/chapter4/section1/subsection4.xml
@@ -631,7 +631,7 @@ output_prompt = "\nM-evaluate value:\n"
 def driver_loop(env, history):
     input = user_read(history)
     if is_none(input):
-        print("", history + "\n--- session end ---\n")
+        print(history + "\n--- session end ---\n", "")
     else:
         program = parse(input)
         locals = scan_out_declarations(program)
@@ -701,7 +701,7 @@ def user_print(string, object):
 def to_string(object):
     return "&lt;compound-function&gt;" if is_compound_function(object) else "&lt;primitive-function&gt;" if is_primitive_function(object) else "[" + to_string(head(object)) + ", " + to_string(tail(object)) + "]" if is_pair(object) else stringify(object)
 def user_print(prompt_string, object):
-    print("----------------------------", prompt_string + "\n" + to_string(object) + "\n")
+    print(prompt_string + "\n" + to_string(object) + "\n", "----------------------------")
 </PYTHON_RUN>
     </SNIPPET>
     <SNIPPET PAGE="383" HIDE="yes">

--- a/xml_py/chapter4/section1/subsection7.xml
+++ b/xml_py/chapter4/section1/subsection7.xml
@@ -255,7 +255,7 @@ analyze(parse("{ const x = 1; x + 1; }")) (the_global_environment)
       </SCHEME>
       <PYTHON>
 def analyze(component):
-    return analyze_literal(component) if is_literal(component) else analyze_name(component) if is_name(component) else analyze_application(component) if is_application(component) else analyze(operator_combination_to_application(component)) if is_operator_combination(component) else analyze_conditional(component) if is_conditional(component) else analyze_lambda_expression(component) if is_lambda_expression(component) else analyze_sequence(sequence_statements(component)) if is_sequence(component) else analyze_block(component) if is_block(component) else analyze_return_statement(component) if is_return_statement(component) else analyze(function_decl_to_constant_decl(component)) if is_function_definition(component) else analyze_declaration(component) if is_declaration(component) else analyze_assignment(component) if is_assignment(component) else error(component, "unknown syntax -- analyze")
+    return analyze_literal(component) if is_literal(component) else analyze_name(component) if is_name(component) else analyze_application(component) if is_application(component) else analyze(operator_combination_to_application(component)) if is_operator_combination(component) else analyze_conditional(component) if is_conditional(component) else analyze_lambda_expression(component) if is_lambda_expression(component) else analyze_sequence(sequence_statements(component)) if is_sequence(component) else analyze_block(component) if is_block(component) else analyze_return_statement(component) if is_return_statement(component) else analyze(function_decl_to_constant_decl(component)) if is_function_definition(component) else analyze_declaration(component) if is_declaration(component) else analyze_assignment(component) if is_assignment(component) else error("unknown syntax -- analyze", component)
 </PYTHON>
     </SNIPPET>
   </TEXT>
@@ -421,7 +421,7 @@ def execute_application(fun, args):
         result = function_body(fun) (extend_environment(function_parameters(fun), args, function_environment(fun)))
         return return_value_content(result) if is_return_value(result) else None
     else:
-        error(fun, "unknown function type -- execute_application")
+        error("unknown function type -- execute_application", fun)
 </PYTHON>
     </SNIPPET>
     </PYTHON>

--- a/xml_py/chapter4/section2/subsection2.xml
+++ b/xml_py/chapter4/section2/subsection2.xml
@@ -224,7 +224,7 @@ evaluate(my_program, the_empty_environment)
       </PYTHON>
       <PYTHON_RUN>
 def evaluate(component, env):
-    return literal_value(component) if is_literal(component) else lookup_symbol_value(symbol_of_name(component), env) if is_name(component) else apply(actual_value(function_expression(component), env), arg_expressions(component), env) if is_application(component) else evaluate(operator_combination_to_application(component), env) if is_operator_combination(component) else eval_conditional(component, env) if is_conditional(component) else make_function(lambda_parameter_symbols(component), lambda_body(component), env) if is_lambda_expression(component) else eval_sequence(sequence_statements(component), env) if is_sequence(component) else eval_block(component, env) if is_block(component) else eval_return_statement(component, env) if is_return_statement(component) else evaluate(function_decl_to_constant_decl(component), env) if is_function_definition(component) else eval_declaration(component, env) if is_declaration(component) else eval_assignment(component, env) if is_assignment(component) else error(component, "unknown syntax -- evaluate")
+    return literal_value(component) if is_literal(component) else lookup_symbol_value(symbol_of_name(component), env) if is_name(component) else apply(actual_value(function_expression(component), env), arg_expressions(component), env) if is_application(component) else evaluate(operator_combination_to_application(component), env) if is_operator_combination(component) else eval_conditional(component, env) if is_conditional(component) else make_function(lambda_parameter_symbols(component), lambda_body(component), env) if is_lambda_expression(component) else eval_sequence(sequence_statements(component), env) if is_sequence(component) else eval_block(component, env) if is_block(component) else eval_return_statement(component, env) if is_return_statement(component) else evaluate(function_decl_to_constant_decl(component), env) if is_function_definition(component) else eval_declaration(component, env) if is_declaration(component) else eval_assignment(component, env) if is_assignment(component) else error("unknown syntax -- evaluate", component)
 </PYTHON_RUN>
     </SNIPPET>
     This is almost the same as the
@@ -381,7 +381,7 @@ def apply(fun, args, env):
         result = evaluate(function_body(fun), extend_environment(function_parameters(fun), list_of_delayed_args(args, env), function_environment(fun)))
         return return_value_content(result) if is_return_value(result) else None
     else:
-        error(fun, "unknown function type -- apply")
+        error("unknown function type -- apply", fun)
 </PYTHON>
     </SNIPPET>
     The
@@ -611,9 +611,9 @@ output_prompt = "L-evaluate value: "
 def driver_loop(env):
     input = user_read(input_prompt)
     if is_none(input):
-        print("--- evaluator terminated ---", "")
+        print("", "--- evaluator terminated ---")
     else:
-        print("----------------------------", input_prompt + "\n" + input + "\n")
+        print(input_prompt + "\n" + input + "\n", "----------------------------")
         program = parse(input)
         locals = scan_out_declarations(program)
         unassigneds = list_of_unassigned(locals)

--- a/xml_py/chapter4/section3/subsection3.xml
+++ b/xml_py/chapter4/section3/subsection3.xml
@@ -453,7 +453,7 @@ $\ldots$
       </SCHEME>
       <PYTHON>
 def analyze(component):
-    return analyze_literal(component) if is_literal(component) else analyze_name(component) if is_name(component) else analyze_amb(component) if is_amb(component) else analyze_application(component) if is_application(component) else analyze(operator_combination_to_application(component)) if is_operator_combination(component) else analyze_conditional(component) if is_conditional(component) else analyze_lambda_expression(component) if is_lambda_expression(component) else analyze_sequence(sequence_statements(component)) if is_sequence(component) else analyze_block(component) if is_block(component) else analyze_return_statement(component) if is_return_statement(component) else analyze(function_decl_to_constant_decl(component)) if is_function_definition(component) else analyze_declaration(component) if is_declaration(component) else analyze_assignment(component) if is_assignment(component) else error(component, "unknown syntax -- analyze")
+    return analyze_literal(component) if is_literal(component) else analyze_name(component) if is_name(component) else analyze_amb(component) if is_amb(component) else analyze_application(component) if is_application(component) else analyze(operator_combination_to_application(component)) if is_operator_combination(component) else analyze_conditional(component) if is_conditional(component) else analyze_lambda_expression(component) if is_lambda_expression(component) else analyze_sequence(sequence_statements(component)) if is_sequence(component) else analyze_block(component) if is_block(component) else analyze_return_statement(component) if is_return_statement(component) else analyze(function_decl_to_constant_decl(component)) if is_function_definition(component) else analyze_declaration(component) if is_declaration(component) else analyze_assignment(component) if is_assignment(component) else error("unknown syntax -- analyze", component)
 </PYTHON>
     </SNIPPET>
     <SNIPPET>
@@ -1275,7 +1275,7 @@ def get_args(afuns, env, succeed, fail):
       </SCHEME>
       <PYTHON>
 def execute_application(fun, args, succeed, fail):
-    return succeed(apply_primitive_function(fun, args), fail) if is_primitive_function(fun) else function_body(fun)(extend_environment(function_parameters(fun), args, function_environment(fun)), lambda body_result, fail2: (succeed(return_value_content(body_result) if is_return_value(body_result) else None, fail2)), fail) if is_compound_function(fun) else error(fun, "unknown function type - execute_application")
+    return succeed(apply_primitive_function(fun, args), fail) if is_primitive_function(fun) else function_body(fun)(extend_environment(function_parameters(fun), args, function_environment(fun)), lambda body_result, fail2: (succeed(return_value_content(body_result) if is_return_value(body_result) else None, fail2)), fail) if is_compound_function(fun) else error("unknown function type - execute_application", fun)
 </PYTHON>
     </SNIPPET>
   </TEXT>
@@ -1556,25 +1556,25 @@ def driver_loop():
     def internal_loop(retry):
         input = user_read(input_prompt)
         if is_none(input):
-            print("--- evaluator terminated ---", "")
+            print("", "--- evaluator terminated ---")
         elif input == "retry":
-            print("----------------------------",
-                    input_prompt + "\n" + input + "\n")
+            print(input_prompt + "\n" + input + "\n",
+                    "----------------------------")
             return retry()
         else:
-            print("--- starting new problem ---",
-                    input_prompt + "\n" + input + "\n")
+            print(input_prompt + "\n" + input + "\n",
+                    "--- starting new problem ---")
             def on_success(val, next_alternative):
                 user_print(output_prompt, val)
                 return internal_loop(next_alternative)
             def on_failure():
-                print("----------------------------",
-                        "no more values of:\n" + input + "\n")
+                print("no more values of:\n" + input + "\n",
+                        "----------------------------")
                 return driver_loop()
             ambeval(parse("{ " + input + " }"),
                 the_global_environment, on_success, on_failure)
     def no_problem():
-        print("---  no current problem  ---", "")
+        print("", "---  no current problem  ---")
         return driver_loop()
     return internal_loop(no_problem)
       </PYTHON_RUN>

--- a/xml_py/chapter4/section4/subsection4.xml
+++ b/xml_py/chapter4/section4/subsection4.xml
@@ -2978,7 +2978,7 @@ function unparse(exp) {
              " " + unparse(second_operand(exp)) +
              ")"
            <METAPHRASE>unparsing other kinds of Python components</METAPHRASE>
-           : error("unknown syntax -- unparse", exp)
+           : error(exp, "unknown syntax -- unparse")
 }
 	    </PYTHON>
 	    <PYTHON_RUN>

--- a/xml_py/chapter4/section4/subsection4.xml
+++ b/xml_py/chapter4/section4/subsection4.xml
@@ -126,7 +126,7 @@ def query_driver_loop():
             add_rule_or_assertion(assertion_body(q))
             print("Assertion added to data base.")
         else:
-            print("------ query results -------", "")
+            print("", "------ query results -------")
             display_stream(stream_map(lambda frame: (unparse(instantiate_expression(exp, frame))), evaluate_query(q, singleton_stream(None))))
         return query_driver_loop()
 </PYTHON_RUN>
@@ -163,7 +163,7 @@ def process_query(input):
             add_rule_or_assertion(assertion_body(q))
             print("Assertion added to data base.")
         else:
-            print("------ query results -------", "")
+            print("", "------ query results -------")
             display_stream(stream_map(lambda frame: (unparse(instantiate_expression(exp, frame))), evaluate_query(q, singleton_stream(None))))
 def first_answer(input):
     exp = parse(input + ";")
@@ -181,7 +181,7 @@ def process_query(input):
         if is_assertion(q):
             add_rule_or_assertion(assertion_body(q))
         else:
-            print("------ query results -------", "")
+            print("", "------ query results -------")
             display_stream(stream_map(lambda frame: (unparse(instantiate_expression(exp, frame))), evaluate_query(q, singleton_stream(None))))
 def first_answer(input):
     exp = parse(input + ";")
@@ -2978,7 +2978,7 @@ function unparse(exp) {
              " " + unparse(second_operand(exp)) +
              ")"
            <METAPHRASE>unparsing other kinds of Python components</METAPHRASE>
-           : error(exp, "unknown syntax -- unparse")
+           : error("unknown syntax -- unparse", exp)
 }
 	    </PYTHON>
 	    <PYTHON_RUN>
@@ -2992,7 +2992,7 @@ def has_char(x, c):
 def better_stringify(x):
     return "'" + x + "'" if is_string(x) and not has_char(x, "'") else stringify(x)
 def unparse(exp):
-    return better_stringify(literal_value(exp)) if is_literal(exp) else symbol_of_name(exp) if is_name(exp) else unparse(make_application(make_name("list"), element_expressions(exp))) if is_list_construction(exp) else symbol_of_name(function_expression(exp)) + "(" + comma_separated(map(unparse, arg_expressions(exp))) + ")" if is_application(exp) and is_name(function_expression(exp)) else "(" + unparse(first_operand(exp)) + " " + operator_symbol(exp) + " " + unparse(second_operand(exp)) + ")" if is_binary_operator_combination(exp) else error(exp, "unknown syntax -- unparse")
+    return better_stringify(literal_value(exp)) if is_literal(exp) else symbol_of_name(exp) if is_name(exp) else unparse(make_application(make_name("list"), element_expressions(exp))) if is_list_construction(exp) else symbol_of_name(function_expression(exp)) + "(" + comma_separated(map(unparse, arg_expressions(exp))) + ")" if is_application(exp) and is_name(function_expression(exp)) else "(" + unparse(first_operand(exp)) + " " + operator_symbol(exp) + " " + unparse(second_operand(exp)) + ")" if is_binary_operator_combination(exp) else error("unknown syntax -- unparse", exp)
 </PYTHON_RUN>
     </SNIPPET>
 	  <SNIPPET>
@@ -3101,9 +3101,9 @@ def element_expressions(list_constr):
 	<REQUIRES>functions_4_1_2</REQUIRES>
 	<PYTHON>
 def type(exp):
-    return head(exp) if is_pair(exp) else error(exp, "unknown expression type")
+    return head(exp) if is_pair(exp) else error("unknown expression type", exp)
 def contents(exp):
-    return tail(exp) if is_pair(exp) else error(exp, "unknown expression contents")
+    return tail(exp) if is_pair(exp) else error("unknown expression contents", exp)
 </PYTHON>
       </SNIPPET>
     </TEXT>

--- a/xml_py/chapter5/section2/subsection1.xml
+++ b/xml_py/chapter5/section2/subsection1.xml
@@ -169,7 +169,7 @@ def make_register(name):
             contents = value
         return (contents if message == "get"
                 else set_value if message == "set"
-                else error(message, "unknown request -- make_register"))
+                else error("unknown request -- make_register", message))
     return dispatch
       </PYTHON>
     </SNIPPET>
@@ -288,7 +288,7 @@ def make_stack():
                 else push_marker() if message == "push_marker"
                 else pop_marker() if message == "pop_marker"
                 else initialize() if message == "initialize"
-                else error(message, "unknown request -- stack"))
+                else error("unknown request -- stack", message))
     return dispatch
 def make_push_marker_to_stack_ef(machine, stack, pc):
     def execution_fun():
@@ -357,7 +357,7 @@ def make_stack():
         return (push if message == "push"
                 else pop() if message == "pop"
                 else initialize() if message == "initialize"
-                else error(message, "unknown request -- stack"))
+                else error("unknown request -- stack", message))
     return dispatch
 </PYTHON>
     </SNIPPET>
@@ -513,11 +513,11 @@ def make_new_machine():
             register_table = pair(llist(name, make_register(name)),
                                   register_table)
         else:
-            error(name, "multiply defined register")
+            error("multiply defined register", name)
         return "register allocated"
     def lookup_register(name):
         val = assoc(name, register_table)
-        return (error(name, "unknown register") if is_undefined(val)
+        return (error("unknown register", name) if is_undefined(val)
                 else head(tail(val)))
     def execute():
         insts = get_contents(pc)
@@ -544,7 +544,7 @@ def make_new_machine():
                 else install_operations if message == "install_operations"
                 else stack if message == "stack"
                 else the_ops if message == "operations"
-                else error(message, "unknown request -- machine"))
+                else error("unknown request -- machine", message))
     return dispatch
 	    </PYTHON>
 	  </SNIPPET>

--- a/xml_py/chapter5/section2/subsection2.xml
+++ b/xml_py/chapter5/section2/subsection2.xml
@@ -477,7 +477,7 @@ def make_label_entry(label_name, insts):
       <PYTHON>
 def lookup_label(labels, label_name):
     val = assoc(label_name, labels)
-    return (error(label_name, "undefined label -- assemble") if is_undefined(val)
+    return (error("undefined label -- assemble", label_name) if is_undefined(val)
             else tail(val))
 </PYTHON>
     </SNIPPET>

--- a/xml_py/chapter5/section2/subsection3.xml
+++ b/xml_py/chapter5/section2/subsection3.xml
@@ -78,7 +78,7 @@ def make_execution_function(inst, labels, machine,
             else make_save_ef(inst, machine, stack, pc) if inst_type == "save"
             else make_restore_ef(inst, machine, stack, pc) if inst_type == "restore"
             else make_perform_ef(inst, machine, labels, ops, pc) if inst_type == "perform"
-            else error(inst, "unknown instruction type -- assemble"))
+            else error("unknown instruction type -- assemble", inst))
 </PYTHON>
     </SNIPPET>
     <SNIPPET HIDE="yes">
@@ -128,7 +128,7 @@ def make_execution_function(inst, labels, machine,
             else make_push_marker_to_stack_ef(machine, stack, pc) if inst_type == "push_marker_to_stack"
             else make_revert_stack_to_marker_ef(machine, stack, pc) if inst_type == "revert_stack_to_marker"
             else make_perform_ef(inst, machine, labels, ops, pc) if inst_type == "perform"
-            else error(inst, "unknown instruction type -- assemble"))
+            else error("unknown instruction type -- assemble", inst))
 </PYTHON>
     </SNIPPET>
     <SPLIT>
@@ -524,7 +524,7 @@ def make_test_ef(inst, machine, labels, operations, flag, pc):
             advance_pc(pc)
         return execution_fun
     else:
-        error(inst, "bad test instruction -- assemble")
+        error("bad test instruction -- assemble", inst)
 </PYTHON>
     </SNIPPET>
     <SPLIT>
@@ -611,7 +611,7 @@ def make_branch_ef(inst, machine, labels, flag, pc):
                 advance_pc(pc)
         return execution_fun
     else:
-        error(inst, "bad branch instruction -- assemble")
+        error("bad branch instruction -- assemble", inst)
 </PYTHON>
     </SNIPPET>
 
@@ -686,7 +686,7 @@ def make_go_to_ef(inst, machine, labels, pc):
         reg = get_register(machine, register_exp_reg(dest))
         return lambda: set_contents(pc, get_contents(reg))
     else:
-        error(inst, "bad go_to instruction -- assemble")
+        error("bad go_to instruction -- assemble", inst)
 </PYTHON>
     </SNIPPET>
 
@@ -846,7 +846,7 @@ def make_perform_ef(inst, machine, labels, operations, pc):
             advance_pc(pc)
         return execution_fun
     else:
-        error(inst, "bad perform instruction -- assemble")
+        error("bad perform instruction -- assemble", inst)
 </PYTHON>
     </SNIPPET>
 
@@ -953,7 +953,7 @@ def make_primitive_exp_ef(exp, machine, labels):
         r = get_register(machine, register_exp_reg(exp))
         return lambda: get_contents(r)
     else:
-        error(exp, "unknown expression type -- assemble")
+        error("unknown expression type -- assemble", exp)
 </PYTHON>
     </SNIPPET>
 
@@ -1225,7 +1225,7 @@ def operation_exp_operands(op_exp):
       <PYTHON>
 def lookup_prim(symbol, operations):
     val = assoc(symbol, operations)
-    return (error(symbol, "unknown operation -- assemble") if is_undefined(val)
+    return (error("unknown operation -- assemble", symbol) if is_undefined(val)
             else head(tail(val)))
 </PYTHON>
     </SNIPPET>

--- a/xml_py/chapter5/section2/subsection4.xml
+++ b/xml_py/chapter5/section2/subsection4.xml
@@ -128,7 +128,7 @@ def make_stack():
                 else pop() if message == "pop"
                 else initialize() if message == "initialize"
                 else print_statistics() if message == "print_statistics"
-                else error(message, "unknown request -- stack"))
+                else error("unknown request -- stack", message))
     return dispatch
 </PYTHON>
     </SNIPPET>

--- a/xml_py/chapter5/section3/subsection2.xml
+++ b/xml_py/chapter5/section3/subsection2.xml
@@ -853,7 +853,7 @@ function get_elem_type(elem) {
         is_string(elem) ? STRING_TYPE :
         is_null(elem) ? NULL_TYPE :
         is_undefined(elem) ? UNDEFINED_TYPE :
-        error("invalid typed elem", elem);
+        error(elem, "invalid typed elem");
 }
 
 function wrap_ptr(elem) {
@@ -1025,7 +1025,7 @@ function make_stack() {
                ? initialize()
                : message === "stack"
                ? stack
-               : error("unknown request -- stack", message);
+               : error(message, "unknown request -- stack");
     }
 
     return dispatch;
@@ -1166,14 +1166,14 @@ function make_new_machine() {
         register_table = pair(list(name, make_register(name)),
                               register_table);
         } else {
-            error("multiply defined register", name);
+            error(name, "multiply defined register");
         }
         return "register allocated";
     }
     function lookup_register(name) {
         const val = assoc(name, register_table);
         return is_undefined(val)
-               ? error("unknown register", name)
+               ? error(name, "unknown register")
                : head(tail(val));
     }
     function execute() {
@@ -1201,7 +1201,7 @@ function make_new_machine() {
                ? stack
                : message === "operations"
                ? the_ops
-               : error("unknown request -- machine", message);
+               : error(message, "unknown request -- machine");
     }
     return dispatch;
 }
@@ -1302,7 +1302,7 @@ function lookup_label(labels, label_name) {
     const val = assoc(label_name, labels);
 
     return is_undefined(val)
-           ? error("undefined label -- assemble", label_name)
+           ? error(label_name, "undefined label -- assemble")
            : tail(val);
 }
 
@@ -1329,7 +1329,7 @@ function make_execution_function(inst, labels, machine, pc, flag, stack, ops) {
                display(stringify(get_register_contents(machine, "the_tails")));
                advance_pc(pc);
            }
-           : error("unknown instruction type -- assemble", inst);
+           : error(inst, "unknown instruction type -- assemble");
 }
 
 function make_assign_ef(inst, machine, labels, operations, pc) {
@@ -1382,7 +1382,7 @@ function make_test_ef(inst, machine, labels, operations, flag, pc) {
 
         return perform_test; 
     } else {
-        error("bad test instruction -- assemble", inst);
+        error(inst, "bad test instruction -- assemble");
     }
 }
 
@@ -1412,7 +1412,7 @@ function make_branch_ef(inst, machine, labels, flag, pc) {
         return perform_branch;
 
     } else {
-        error("bad branch instruction -- assemble", inst);
+        error(inst, "bad branch instruction -- assemble");
     }
 }
 
@@ -1436,7 +1436,7 @@ function make_goto(inst, machine, labels, pc) {
         return () => set_contents(pc, get_contents(reg));
 
     } else {
-        error("bad go_to instruction -- assemble", inst);
+        error(inst, "bad go_to instruction -- assemble");
     }
 }
 
@@ -1491,7 +1491,7 @@ function make_perform_ef(inst, machine, labels, operations, pc) {
         return () => { action_fun(); advance_pc(pc); };
 
     } else {
-        error("bad perform instruction -- assemble", inst);
+        error(inst, "bad perform instruction -- assemble");
     }
 }
 
@@ -1518,7 +1518,7 @@ function make_primitive_exp_ef(exp, machine, labels) {
         return () => get_contents(r); 
 
     } else {
-        error("unknown expression type -- assemble", exp);
+        error(exp, "unknown expression type -- assemble");
     }
 }
 
@@ -1594,7 +1594,7 @@ function lookup_prim(symbol, operations) {
     const val = assoc(symbol, operations);
 
     return is_undefined(val)
-           ? error("unknown operation -- assemble", symbol)
+           ? error(symbol, "unknown operation -- assemble")
            : head(tail(val));
 }
 

--- a/xml_py/chapter5/section3/subsection2.xml
+++ b/xml_py/chapter5/section3/subsection2.xml
@@ -853,7 +853,7 @@ function get_elem_type(elem) {
         is_string(elem) ? STRING_TYPE :
         is_null(elem) ? NULL_TYPE :
         is_undefined(elem) ? UNDEFINED_TYPE :
-        error(elem, "invalid typed elem");
+        error("invalid typed elem", elem);
 }
 
 function wrap_ptr(elem) {
@@ -1025,7 +1025,7 @@ function make_stack() {
                ? initialize()
                : message === "stack"
                ? stack
-               : error(message, "unknown request -- stack");
+               : error("unknown request -- stack", message);
     }
 
     return dispatch;
@@ -1166,14 +1166,14 @@ function make_new_machine() {
         register_table = pair(list(name, make_register(name)),
                               register_table);
         } else {
-            error(name, "multiply defined register");
+            error("multiply defined register", name);
         }
         return "register allocated";
     }
     function lookup_register(name) {
         const val = assoc(name, register_table);
         return is_undefined(val)
-               ? error(name, "unknown register")
+               ? error("unknown register", name)
                : head(tail(val));
     }
     function execute() {
@@ -1201,7 +1201,7 @@ function make_new_machine() {
                ? stack
                : message === "operations"
                ? the_ops
-               : error(message, "unknown request -- machine");
+               : error("unknown request -- machine", message);
     }
     return dispatch;
 }
@@ -1302,7 +1302,7 @@ function lookup_label(labels, label_name) {
     const val = assoc(label_name, labels);
 
     return is_undefined(val)
-           ? error(label_name, "undefined label -- assemble")
+           ? error("undefined label -- assemble", label_name)
            : tail(val);
 }
 
@@ -1329,7 +1329,7 @@ function make_execution_function(inst, labels, machine, pc, flag, stack, ops) {
                display(stringify(get_register_contents(machine, "the_tails")));
                advance_pc(pc);
            }
-           : error(inst, "unknown instruction type -- assemble");
+           : error("unknown instruction type -- assemble", inst);
 }
 
 function make_assign_ef(inst, machine, labels, operations, pc) {
@@ -1382,7 +1382,7 @@ function make_test_ef(inst, machine, labels, operations, flag, pc) {
 
         return perform_test; 
     } else {
-        error(inst, "bad test instruction -- assemble");
+        error("bad test instruction -- assemble", inst);
     }
 }
 
@@ -1412,7 +1412,7 @@ function make_branch_ef(inst, machine, labels, flag, pc) {
         return perform_branch;
 
     } else {
-        error(inst, "bad branch instruction -- assemble");
+        error("bad branch instruction -- assemble", inst);
     }
 }
 
@@ -1436,7 +1436,7 @@ function make_goto(inst, machine, labels, pc) {
         return () => set_contents(pc, get_contents(reg));
 
     } else {
-        error(inst, "bad go_to instruction -- assemble");
+        error("bad go_to instruction -- assemble", inst);
     }
 }
 
@@ -1491,7 +1491,7 @@ function make_perform_ef(inst, machine, labels, operations, pc) {
         return () => { action_fun(); advance_pc(pc); };
 
     } else {
-        error(inst, "bad perform instruction -- assemble");
+        error("bad perform instruction -- assemble", inst);
     }
 }
 
@@ -1518,7 +1518,7 @@ function make_primitive_exp_ef(exp, machine, labels) {
         return () => get_contents(r); 
 
     } else {
-        error(exp, "unknown expression type -- assemble");
+        error("unknown expression type -- assemble", exp);
     }
 }
 
@@ -1594,7 +1594,7 @@ function lookup_prim(symbol, operations) {
     const val = assoc(symbol, operations);
 
     return is_undefined(val)
-           ? error(symbol, "unknown operation -- assemble")
+           ? error("unknown operation -- assemble", symbol)
            : head(tail(val));
 }
 

--- a/xml_py/chapter5/section5/subsection1.xml
+++ b/xml_py/chapter5/section5/subsection1.xml
@@ -181,7 +181,7 @@ function compile(component, target, linkage) {
            ? compile_declaration(component, target, linkage)
            : is_assignment(component)
            ? compile_assignment(component, target, linkage)
-           : error("unknown component type -- compile", component);
+           : error(component, "unknown component type -- compile");
 }
       </PYTHON>
     </SNIPPET>

--- a/xml_py/chapter5/section5/subsection1.xml
+++ b/xml_py/chapter5/section5/subsection1.xml
@@ -181,7 +181,7 @@ function compile(component, target, linkage) {
            ? compile_declaration(component, target, linkage)
            : is_assignment(component)
            ? compile_assignment(component, target, linkage)
-           : error(component, "unknown component type -- compile");
+           : error("unknown component type -- compile", component);
 }
       </PYTHON>
     </SNIPPET>

--- a/xml_py/chapter5/section5/subsection3.xml
+++ b/xml_py/chapter5/section5/subsection3.xml
@@ -1379,7 +1379,7 @@ function compile_fun_appl(target, linkage) {
                                          reg("fun"))),
                       go_to(reg("val"))))
            : // $\texttt{target !== "val" \&amp;\&amp; linkage === "return"}$
-             error("return linkage, target not val -- compile", target);
+             error(target, "return linkage, target not val -- compile");
 }
       </PYTHON>
     </SNIPPET>

--- a/xml_py/chapter5/section5/subsection3.xml
+++ b/xml_py/chapter5/section5/subsection3.xml
@@ -1379,7 +1379,7 @@ function compile_fun_appl(target, linkage) {
                                          reg("fun"))),
                       go_to(reg("val"))))
            : // $\texttt{target !== "val" \&amp;\&amp; linkage === "return"}$
-             error(target, "return linkage, target not val -- compile");
+             error("return linkage, target not val -- compile", target);
 }
       </PYTHON>
     </SNIPPET>


### PR DESCRIPTION
Fixes #1276

## Summary
`xml_py` mechanically copied JS's `error(datum, "message")` argument order. JS's `error`/`display` intentionally reverse (print arg 2 before arg 1) to reproduce Scheme's original message-first convention — e.g. the Scheme original is `(error "Unknown request - - MAKE-ACCOUNT" m)`, message first. Python's `error(*args)` (checked in the published `sourceacademy-sicp` PyPI package: `raise Exception("Error: " + " ".join(str(a) for a in args))`) joins arguments in the given order, **not reversed**, so the copied argument order produced `Error: <datum> <message>` instead of the intended `Error: <message> <datum>`. Same mechanism affects the handful of two-argument `print()` calls in the chapter 4 driver-loop code.

Swapped all **134 two-argument `print()`/`error()` call sites across 33 files** (122 `error()`, 12 `print()`) to restore the intended order.

Full inventory and root-cause analysis: [issue comment](https://github.com/source-academy/sicp/issues/1276#issuecomment-4967149765).

## How the fix was applied
Scripted (bracket/string-aware parser, not a naive regex) so nested calls like `error(llist(op, type_tags), "message")` swap correctly to `error("message", llist(op, type_tags))` without corrupting the datum expression, and multi-line calls keep their original line-break/indent style rather than being jammed onto one line.

## Test plan
- [x] Diff is a clean 146 insertions / 146 deletions across 33 files — one line changed per call site, nothing else touched.
- [x] Rebuilt `json_py` before and after: identical warning count (406), confirming no new parse issues.
- [x] Ran `ast.parse` on every `<PYTHON>`/`<PYTHON_RUN>`/`<PYTHON_TEST>` code block in all 33 changed files, before vs. after — **zero newly-broken blocks** (blocks that already didn't parse standalone, e.g. fragments needing external context, are identical in both).
- [x] Spot-checked the rendered chapter JSON (e.g. `json_py/3.1.1.json`) and raw XML for several swapped calls to confirm the argument order is correct in the actual output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)