### PR TITLE
Add SICP_PUBLISHED_CHAPTERS gate for staged chapter publishing

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -43,10 +43,20 @@ jobs:
       # The Python edition is published additively (split_py/, json_py/,
       # sicpy.pdf, sicpy.zip, sicpy.md). Best-effort: any failure here must
       # never block the already-assembled JavaScript deploy.
+      #
+      # SICP_PUBLISHED_CHAPTERS restricts chapters 1..N to the live site
+      # while later chapters are still authored, tested, and readable
+      # locally; the mechanism applies to any edition (see
+      # getPublishedChapterCount() in javascript/editions.ts), but only
+      # this step sets it — the JS/Scheme builds above/below leave it
+      # unset and always publish all chapters, since those editions are
+      # already complete. Bump this number in a PR as each next chapter
+      # is ready to publish — no other change needed.
       - name: Build (Python edition)
         continue-on-error: true
         env:
           SICP_EDITION: py
+          SICP_PUBLISHED_CHAPTERS: "2"
         run: |
           set -euxo pipefail
           yarn run split

--- a/javascript/commands/utils.ts
+++ b/javascript/commands/utils.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import fse from "fs-extra";
 import path from "node:path";
 import { ending, frontmatter, preamble } from "../latexContent.js";
-import { getEdition } from "../editions.js";
+import { getEdition, getPublishedChapterCount } from "../editions.js";
 
 const __dirname = path.resolve(import.meta.dirname);
 
@@ -33,10 +33,15 @@ export const createMain = (
   // for latex version only
   // create the root <edition>.tex file (sicpjs.tex / sicpy.tex)
   // FIXME: Remove any
+  // Chapters beyond the published cutoff never had their .tex fragments
+  // generated (index.ts skips them for the same reason), so they must be
+  // excluded here too, or \input below would point at a missing file.
+  const publishedChapterCount = getPublishedChapterCount();
   const chaptersFound: any[] = [];
   const files = fs.readdirSync(inputDir);
   files.forEach(file => {
-    if (file.match(/chapter/)) {
+    const chapterMatch = file.match(/^chapter(\d+)$/);
+    if (chapterMatch && Number(chapterMatch[1]) <= publishedChapterCount) {
       chaptersFound.push(file);
     }
   });

--- a/javascript/editions.ts
+++ b/javascript/editions.ts
@@ -120,6 +120,31 @@ export const schemeEdition: Edition = {
   outputBaseName: "sicp" // the original SICP
 };
 
+// Total number of chapters the book is structured into (xml/ and xml_py/
+// each have chapter1/ .. chapter5/). Used together with
+// getPublishedChapterCount() to describe the still-unpublished range.
+export const TOTAL_CHAPTER_COUNT = 5;
+
+// Chapters beyond this cutoff are excluded from every build target (PDF,
+// web, JSON, Markdown, programs), via the SICP_PUBLISHED_CHAPTERS env var,
+// so a chapter in progress can still be authored, built, tested, and read
+// locally while being held back from the deployed site. Unset means
+// "publish everything" — the default for every local command. The
+// mechanism applies uniformly to any edition; in practice only the Python
+// edition's deploy step sets the env var, since JS and Scheme are already
+// complete and always publish every chapter.
+export function getPublishedChapterCount(): number {
+  const raw = process.env.SICP_PUBLISHED_CHAPTERS?.trim();
+  if (!raw) return TOTAL_CHAPTER_COUNT;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1) {
+    throw new Error(
+      `Invalid SICP_PUBLISHED_CHAPTERS "${process.env.SICP_PUBLISHED_CHAPTERS}" (expected a positive integer)`
+    );
+  }
+  return n;
+}
+
 export function getCompanionLanguage(
   edition: Edition = getEdition()
 ): LanguageDescriptor {

--- a/javascript/generateTocHtml.tsx
+++ b/javascript/generateTocHtml.tsx
@@ -11,6 +11,7 @@ import { generateChapterIndex } from "./tocUtils.js";
 import { IndexHeaderCard, SidebarHeaderCard } from "./TocCards.js";
 import { html, raw } from "hono/html";
 import type { WriteBuffer } from "./types.js";
+import { getPublishedChapterCount, TOTAL_CHAPTER_COUNT } from "./editions.js";
 
 const truncateTitle = chapterTitle => {
   let truncatedTitle = "";
@@ -232,6 +233,24 @@ export const indexHtml = (writeToIndex: WriteBuffer) => {
     <div class="chapter-content">
     <div class="chapter-text" >`);
   indexPage(writeToIndex);
+
+  const publishedChapterCount = getPublishedChapterCount();
+  if (publishedChapterCount < TOTAL_CHAPTER_COUNT) {
+    const from = publishedChapterCount + 1;
+    const range =
+      from === TOTAL_CHAPTER_COUNT
+        ? `Chapter ${from}`
+        : `Chapters ${from}–${TOTAL_CHAPTER_COUNT}`;
+    const verb = from === TOTAL_CHAPTER_COUNT ? "is" : "are";
+    writeToIndex.push(html`
+      <p style="font-style:italic">
+        ${raw(range)} ${raw(verb)} still in preparation and will be published
+        here as
+        ${raw(from === TOTAL_CHAPTER_COUNT ? "it becomes" : "they become")}
+        ready.
+      </p>
+    `);
+  }
 
   // TOC at index page
   writeToIndex.push("<h2>Content</h2>");

--- a/javascript/index.ts
+++ b/javascript/index.ts
@@ -45,7 +45,7 @@ import { setupSnippetsJson } from "./processingFunctions/processSnippetJson.js";
 import { createTocJson } from "./generateTocJson.js";
 import { setupReferencesJson } from "./processingFunctions/processReferenceJson.js";
 import { createMain } from "./commands/utils.js";
-import { getEdition } from "./editions.js";
+import { getEdition, getPublishedChapterCount } from "./editions.js";
 import type { WriteBuffer } from "./types.js";
 
 export let parseType;
@@ -66,6 +66,15 @@ const inputDir = path.join(__dirname, "..", edition.inputDirName);
 const isPythonEdition = edition.language.key === "py";
 const pythonExcludedFrontmatter =
   /(02foreword02|03prefaces03|04acknowledgements04)/;
+
+// Chapters beyond this cutoff (see getPublishedChapterCount) are skipped
+// wholesale below, for every build target that walks this tree (web, json,
+// md, programs) and every edition, so they never reach the deployed site.
+const publishedChapterCount = getPublishedChapterCount();
+const unpublishedChapterDir = (dirName: string): boolean => {
+  const match = dirName.match(/^chapter(\d+)$/);
+  return match !== null && Number(match[1]) > publishedChapterCount;
+};
 
 const ensureDirectoryExists = (path, cb) => {
   fs.mkdir(path, err => {
@@ -265,7 +274,11 @@ async function recursiveTranslateXml(filepath, option) {
         promises.push(translateXml(filepath, file, option));
       }
     } else if (fs.lstatSync(path.join(fullPath, file)).isDirectory()) {
-      promises.push(recursiveTranslateXml(path.join(filepath, file), option));
+      if (unpublishedChapterDir(file)) {
+        // held back from this build (see getPublishedChapterCount)
+      } else {
+        promises.push(recursiveTranslateXml(path.join(filepath, file), option));
+      }
     }
   });
   await Promise.all(promises);


### PR DESCRIPTION
## Summary
- Chapters 1-2 are ready for semester prep; Python-edition chapters 3-5 are still being converted/authored.
- Adds `SICP_PUBLISHED_CHAPTERS` (a chapter-number cutoff): unset (the default everywhere except deploy) publishes everything, so local builds/tests/reads of chapters 3-5 are unaffected.
- Gated at the two build choke points: `index.ts`'s file-tree walk (web/json/md/programs, any edition) and `commands/utils.ts`'s PDF `\input` list.
- `generateTocHtml.tsx` adds a generated "Chapters N–5 are still in preparation" note to the landing page when the cutoff is active.
- `deploy-pages.yml` sets `SICP_PUBLISHED_CHAPTERS: "2"` only on the Python edition build step — JS and Scheme are already complete and keep publishing every chapter. The mechanism itself is edition-agnostic; promoting a chapter later is a one-line bump of that number.

## Test plan
- [x] `SICP_PUBLISHED_CHAPTERS=2 tsx javascript/index.js json` (JS edition) → toc stops at chapter 2, no missing-file errors
- [x] Same for `SICP_EDITION=py` and `SICP_EDITION=scm`
- [x] Unset var → all 5 chapters present for every edition (matches current deploy behavior)
- [x] `tsx javascript/index.js pdf` with the gate set → `\input` list in `sicpjs.tex` stops at chapter2, no dangling references to ungenerated `.tex` fragments
- [x] `prettier --list-different "javascript"` clean

## Known side effect
Forward cross-references from a published chapter into a still-gated one (e.g. chapter 2 referencing something defined in chapter 3) produce a "REF not found" build warning and may render as a broken link until that chapter is promoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAAMFom423g6SSSrgsMxGC